### PR TITLE
[Fix] corner case of `chain_single_qubit_ops`

### DIFF
--- a/qadence/transpile/block.py
+++ b/qadence/transpile/block.py
@@ -406,7 +406,14 @@ def chain_single_qubit_ops(block: AbstractBlock) -> AbstractBlock:
     ```
     """
     if is_chain_of_primitivekrons(block):
-        return kron(*map(lambda bs: chain(*bs), zip(*block)))  # type: ignore[misc]
+        try:
+            return kron(*map(lambda bs: chain(*bs), zip(*block)))  # type: ignore[misc]
+        except Exception as e:
+            logger.debug(
+                f"Unable to transpile {block} using chain_single_qubit_ops\
+                         due to {e}. Returning original circuit."
+            )
+            return block
 
     elif isinstance(block, CompositeBlock):
         return _construct(type(block), tuple(chain_single_qubit_ops(b) for b in block.blocks))

--- a/tests/qadence/test_transpile.py
+++ b/tests/qadence/test_transpile.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from qadence import chain, kron
 from qadence.blocks import AbstractBlock, AddBlock, ChainBlock, KronBlock
-from qadence.transpile import chain_single_qubit_ops, digitalize, flatten
 from qadence.operations import RX, RZ, H, HamEvo, X
+from qadence.transpile import chain_single_qubit_ops, digitalize, flatten
 from qadence.types import LTSOrder
 
 

--- a/tests/qadence/test_transpile.py
+++ b/tests/qadence/test_transpile.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from qadence import RX, RZ, H, HamEvo, X, chain, kron
 from qadence.blocks import AbstractBlock, AddBlock, ChainBlock, KronBlock
-from qadence.transpile import digitalize, flatten
+from qadence.transpile import chain_single_qubit_ops, digitalize, flatten
 from qadence.types import LTSOrder
 
 
@@ -47,3 +47,8 @@ def test_flatten() -> None:
     assert digitalize(x, LTSOrder.BASIC) == chain(
         chain(X(0), chain(H(0), RZ(0, 4.0), H(0)), RX(0, 2.0))
     )
+
+
+def test_chain_of_krons() -> None:
+    b = chain(kron(X(0), X(2)), kron(X(0), X(2)))
+    assert chain_single_qubit_ops(b) == kron(chain(X(0), X(0)), chain(X(2), X(2)))


### PR DESCRIPTION
When the krons in a chain of krons where not covering the whole qubit support `chain_single_qubit_ops` was failling