### PR TITLE
[Fix] Braket CPHASE always having fixed parameters

### DIFF
--- a/qadence/backends/braket/convert_ops.py
+++ b/qadence/backends/braket/convert_ops.py
@@ -81,13 +81,19 @@ def BraketOperation(block: PrimitiveBlock) -> Instruction:
         return two_qubit[operation](block.qubit_support[0], block.qubit_support[1])
 
     elif operation in two_qubit_parametrized:
-        (expr,) = block.parameters.expressions()  # type: ignore [attr-defined]
-        angle_value = evaluate(expr)
-        return two_qubit_parametrized[operation](
-            control=block.qubit_support[0],
-            target=block.qubit_support[1],
-            angle=angle_value,
-        )
+        ((uuid, expr),) = block.parameters.items()  # type: ignore [attr-defined]
+        if expr.is_number:
+            return two_qubit_parametrized[operation](
+                control=block.qubit_support[0],
+                target=block.qubit_support[1],
+                angle=evaluate(expr),
+            )
+        else:
+            return two_qubit_parametrized[operation](
+                control=block.qubit_support[0],
+                target=block.qubit_support[1],
+                angle=FreeParameter(uuid),
+            )
     elif operation in three_qubit:
         return three_qubit[operation](
             block.qubit_support[0], block.qubit_support[1], block.qubit_support[2]

--- a/tests/backends/test_backends.py
+++ b/tests/backends/test_backends.py
@@ -11,13 +11,13 @@ from hypothesis import given, settings
 from metrics import ATOL_DICT, JS_ACCEPTANCE  # type: ignore
 from torch import Tensor
 
-from qadence import BackendName, DiffMode
 from qadence.backend import BackendConfiguration
 from qadence.backends.api import backend_factory, config_factory
 from qadence.blocks import AbstractBlock, chain, kron
 from qadence.circuit import QuantumCircuit
 from qadence.constructors import total_magnetization
 from qadence.divergences import js_divergence
+from qadence.execution import run
 from qadence.ml_tools.utils import rand_featureparameters
 from qadence.models import QuantumModel
 from qadence.operations import CPHASE, RX, RY, H, I, X
@@ -30,6 +30,7 @@ from qadence.states import (
     zero_state,
 )
 from qadence.transpile import flatten
+from qadence.types import BackendName, DiffMode
 from qadence.utils import nqubits_to_basis
 
 BACKENDS = BackendName.list()
@@ -340,3 +341,12 @@ def test_custom_transpilation_passes() -> None:
 
         assert conv.circuit.original == conv_no_transp.circuit.original
         assert conv.circuit.abstract != conv_no_transp.circuit.abstract
+
+
+def test_braket_parametric_cphase() -> None:
+    param_name = "y"
+    block = chain(X(0), H(1), CPHASE(0, 1, param_name))
+    values = {param_name: torch.rand(1)}
+    equivalent_state(
+        run(block, values=values, backend="braket"), run(block, values=values, backend="pyqtorch")
+    )


### PR DESCRIPTION
Previously, the cphase gate in braket was ALWAYS initialized with a fixed parameter instead of checking if the underlying expression contains trainable symbols, now its possible