### PR TITLE
[Refac] Cleanup imports

### DIFF
--- a/examples/backends/low_level/braket_digital.py
+++ b/examples/backends/low_level/braket_digital.py
@@ -15,8 +15,7 @@ from qadence import (
     chain,
     total_magnetization,
 )
-from qadence.backend import BackendName
-from qadence.backends.pytorch_wrapper import DiffMode
+from qadence.types import BackendName, DiffMode
 
 # def circuit(n_qubits):
 #     # make feature map with input parameters

--- a/examples/models/quantum_model.py
+++ b/examples/models/quantum_model.py
@@ -14,8 +14,7 @@ from qadence import (
     chain,
     total_magnetization,
 )
-from qadence.backend import BackendName
-from qadence.backends.pytorch_wrapper import DiffMode
+from qadence.types import BackendName, DiffMode
 
 torch.manual_seed(42)
 

--- a/qadence/analog/interaction.py
+++ b/qadence/analog/interaction.py
@@ -19,9 +19,9 @@ from qadence.blocks.analog import (
 )
 from qadence.blocks.composite import CompositeBlock
 from qadence.blocks.primitive import PrimitiveBlock, ScaleBlock
-from qadence.blocks.utils import _construct
+from qadence.blocks.utils import _construct, add, chain, kron
 from qadence.circuit import QuantumCircuit
-from qadence.operations import HamEvo, I, add, chain, kron, wait
+from qadence.operations import HamEvo, I, wait
 from qadence.qubit_support import QubitSupport
 from qadence.register import Register
 from qadence.transpile.transpile import blockfn_to_circfn

--- a/qadence/analog/utils.py
+++ b/qadence/analog/utils.py
@@ -8,7 +8,8 @@ from qadence.blocks.abstract import AbstractBlock
 from qadence.blocks.analog import (
     ConstantAnalogRotation,
 )
-from qadence.operations import N, X, Y, add, kron
+from qadence.blocks.utils import add, kron
+from qadence.operations import N, X, Y
 from qadence.register import Register
 
 # Ising coupling coefficient depending on the Rydberg level

--- a/qadence/backends/__init__.py
+++ b/qadence/backends/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from .api import backend_factory, config_factory
-from .pytorch_wrapper import DifferentiableBackend, DiffMode
+from .pytorch_wrapper import DifferentiableBackend
 
 # Modules to be automatically added to the qadence namespace
-__all__ = ["backend_factory", "config_factory", "DifferentiableBackend", "DiffMode"]
+__all__ = ["backend_factory", "config_factory", "DifferentiableBackend"]

--- a/qadence/backends/api.py
+++ b/qadence/backends/api.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from qadence.backend import Backend, BackendConfiguration
-from qadence.backends.pytorch_wrapper import DifferentiableBackend, DiffMode
+from qadence.backends.pytorch_wrapper import DifferentiableBackend
 from qadence.extensions import available_backends, set_backend_config
-from qadence.types import BackendName
+from qadence.types import BackendName, DiffMode
 
 __all__ = ["backend_factory", "config_factory"]
 

--- a/qadence/backends/braket/backend.py
+++ b/qadence/backends/braket/backend.py
@@ -11,13 +11,14 @@ from braket.devices import LocalSimulator
 from torch import Tensor
 
 from qadence.backend import Backend as BackendInterface
-from qadence.backend import BackendName, ConvertedCircuit, ConvertedObservable
+from qadence.backend import ConvertedCircuit, ConvertedObservable
 from qadence.backends.utils import to_list_of_dicts
 from qadence.blocks import AbstractBlock, block_to_tensor
 from qadence.circuit import QuantumCircuit
 from qadence.measurements import Measurements
 from qadence.overlap import overlap_exact
 from qadence.transpile import transpile
+from qadence.types import BackendName
 from qadence.utils import Endianness
 
 from .config import Configuration, default_passes

--- a/qadence/backends/pulser/backend.py
+++ b/qadence/backends/pulser/backend.py
@@ -14,7 +14,7 @@ from pulser_simulation.simulation import QutipEmulator
 from torch import Tensor
 
 from qadence.backend import Backend as BackendInterface
-from qadence.backend import BackendName, ConvertedCircuit, ConvertedObservable
+from qadence.backend import ConvertedCircuit, ConvertedObservable
 from qadence.backends.utils import to_list_of_dicts
 from qadence.blocks import AbstractBlock
 from qadence.circuit import QuantumCircuit
@@ -22,6 +22,7 @@ from qadence.measurements import Measurements
 from qadence.overlap import overlap_exact
 from qadence.register import Register
 from qadence.transpile import transpile
+from qadence.types import BackendName
 from qadence.utils import Endianness, get_logger
 
 from .channels import GLOBAL_CHANNEL, LOCAL_CHANNEL

--- a/qadence/blocks/matrix.py
+++ b/qadence/blocks/matrix.py
@@ -25,8 +25,7 @@ class MatrixBlock(PrimitiveBlock):
         import torch
 
     from qadence import QuantumCircuit
-    from qadence.backend import BackendName
-    from qadence.backends.api import DiffMode
+    from qadence.types import BackendName, DiffMode
     from qadence.blocks.matrix import MatrixBlock
     from qadence.models import QuantumModel
     from qadence.operations import X, Z

--- a/qadence/blocks/matrix.py
+++ b/qadence/blocks/matrix.py
@@ -24,7 +24,7 @@ class MatrixBlock(PrimitiveBlock):
     ```python exec="on" source="material-block" result="json"
         import torch
 
-    from qadence import QuantumCircuit
+    from qadence.circuit import QuantumCircuit
     from qadence.types import BackendName, DiffMode
     from qadence.blocks.matrix import MatrixBlock
     from qadence.models import QuantumModel

--- a/qadence/execution.py
+++ b/qadence/execution.py
@@ -6,14 +6,13 @@ from typing import Any, Union
 
 from torch import Tensor, no_grad
 
-from qadence import backend_factory
-from qadence.backend import BackendConfiguration, BackendName
+from qadence.backend import BackendConfiguration
+from qadence.backends.api import backend_factory
 from qadence.blocks import AbstractBlock
 from qadence.circuit import QuantumCircuit
 from qadence.qubit_support import QubitSupport
 from qadence.register import Register
-from qadence.types import DiffMode
-from qadence.utils import Endianness
+from qadence.types import BackendName, DiffMode, Endianness
 
 # Modules to be automatically added to the qadence namespace
 __all__ = ["run", "sample", "expectation"]

--- a/qadence/measurements/shadow.py
+++ b/qadence/measurements/shadow.py
@@ -18,9 +18,9 @@ from qadence.blocks.block_to_tensor import (
 )
 from qadence.blocks.composite import CompositeBlock
 from qadence.blocks.primitive import PrimitiveBlock
-from qadence.blocks.utils import get_pauli_blocks, unroll_block_with_scaling
+from qadence.blocks.utils import chain, get_pauli_blocks, kron, unroll_block_with_scaling
 from qadence.circuit import QuantumCircuit
-from qadence.operations import X, Y, Z, chain, kron
+from qadence.operations import X, Y, Z
 from qadence.states import one_state, zero_state
 from qadence.types import BackendName, DiffMode, Endianness
 

--- a/qadence/measurements/shadow.py
+++ b/qadence/measurements/shadow.py
@@ -7,7 +7,6 @@ import numpy as np
 import torch
 from torch import Tensor
 
-from qadence import BackendName, DiffMode
 from qadence.backends import backend_factory
 from qadence.blocks.abstract import AbstractBlock
 from qadence.blocks.block_to_tensor import (
@@ -23,7 +22,7 @@ from qadence.blocks.utils import get_pauli_blocks, unroll_block_with_scaling
 from qadence.circuit import QuantumCircuit
 from qadence.operations import X, Y, Z, chain, kron
 from qadence.states import one_state, zero_state
-from qadence.types import Endianness
+from qadence.types import BackendName, DiffMode, Endianness
 
 pauli_gates = [X, Y, Z]
 

--- a/qadence/measurements/tomography.py
+++ b/qadence/measurements/tomography.py
@@ -7,13 +7,13 @@ import numpy as np
 import torch
 from torch import Tensor
 
-from qadence import BackendName, DiffMode
 from qadence.backends import backend_factory
 from qadence.blocks import AbstractBlock, PrimitiveBlock
 from qadence.blocks.utils import unroll_block_with_scaling
 from qadence.circuit import QuantumCircuit
 from qadence.operations import H, SDagger, X, Y, Z, chain
 from qadence.parameters import evaluate
+from qadence.types import BackendName, DiffMode
 from qadence.utils import Endianness
 
 

--- a/qadence/measurements/tomography.py
+++ b/qadence/measurements/tomography.py
@@ -9,9 +9,9 @@ from torch import Tensor
 
 from qadence.backends import backend_factory
 from qadence.blocks import AbstractBlock, PrimitiveBlock
-from qadence.blocks.utils import unroll_block_with_scaling
+from qadence.blocks.utils import chain, unroll_block_with_scaling
 from qadence.circuit import QuantumCircuit
-from qadence.operations import H, SDagger, X, Y, Z, chain
+from qadence.operations import H, SDagger, X, Y, Z
 from qadence.parameters import evaluate
 from qadence.types import BackendName, DiffMode
 from qadence.utils import Endianness

--- a/qadence/models/qnn.py
+++ b/qadence/models/qnn.py
@@ -4,13 +4,12 @@ from typing import Callable
 
 from torch import Tensor
 
-from qadence.backend import BackendConfiguration, BackendName
-from qadence.backends.pytorch_wrapper import DiffMode
-from qadence.blocks import AbstractBlock
+from qadence.backend import BackendConfiguration
+from qadence.blocks.abstract import AbstractBlock
 from qadence.circuit import QuantumCircuit
 from qadence.measurements import Measurements
 from qadence.models.quantum_model import QuantumModel
-from qadence.utils import Endianness
+from qadence.types import BackendName, DiffMode, Endianness
 
 
 class QNN(QuantumModel):

--- a/qadence/models/quantum_model.py
+++ b/qadence/models/quantum_model.py
@@ -16,13 +16,12 @@ from qadence.backend import (
     ConvertedCircuit,
     ConvertedObservable,
 )
-from qadence.backends import backend_factory, config_factory
-from qadence.backends.pytorch_wrapper import DiffMode
-from qadence.blocks import AbstractBlock
+from qadence.backends.api import backend_factory, config_factory
+from qadence.blocks.abstract import AbstractBlock
 from qadence.circuit import QuantumCircuit
 from qadence.logger import get_logger
 from qadence.measurements import Measurements
-from qadence.utils import Endianness
+from qadence.types import DiffMode, Endianness
 
 logger = get_logger(__name__)
 

--- a/qadence/overlap.py
+++ b/qadence/overlap.py
@@ -7,16 +7,16 @@ import numpy as np
 import torch
 from torch import Tensor
 
-from qadence.backend import BackendConfiguration, BackendName
-from qadence.backends.pytorch_wrapper import DiffMode
-from qadence.blocks import AbstractBlock, chain, kron, tag
+from qadence.backend import BackendConfiguration
+from qadence.blocks.abstract import AbstractBlock
+from qadence.blocks.utils import chain, kron, tag
 from qadence.circuit import QuantumCircuit
 from qadence.divergences import js_divergence
 from qadence.measurements import Measurements
-from qadence.models import QuantumModel
+from qadence.models.quantum_model import QuantumModel
 from qadence.operations import SWAP, H, I, S, Z
 from qadence.transpile import reassign
-from qadence.types import OverlapMethod
+from qadence.types import BackendName, DiffMode, OverlapMethod
 
 # Modules to be automatically added to the qadence namespace
 __all__ = ["Overlap", "OverlapMethod"]

--- a/qadence/parameters.py
+++ b/qadence/parameters.py
@@ -73,7 +73,7 @@ class Parameter(Symbol):
 
         Example:
         ```python exec="on" source="material-block" result="json"
-        from qadence import Parameter, VariationalParameter
+        from qadence.parameters import Parameter, VariationalParameter
 
         theta = Parameter("theta")
         print(f"{theta}: trainable={theta.trainable} value={theta.value}")

--- a/qadence/states.py
+++ b/qadence/states.py
@@ -8,13 +8,12 @@ import torch
 from torch import Tensor, concat
 from torch.distributions import Categorical, Distribution
 
-from qadence import BackendName
 from qadence.backends.api import backend_factory
 from qadence.blocks import ChainBlock, KronBlock, PrimitiveBlock, chain, kron
 from qadence.circuit import QuantumCircuit
 from qadence.operations import CNOT, RX, RY, RZ, H, I, X
 from qadence.overlap import fidelity
-from qadence.types import Endianness, StateGeneratorType
+from qadence.types import BackendName, Endianness, StateGeneratorType
 from qadence.utils import basis_to_int
 
 # Modules to be automatically added to the qadence namespace

--- a/qadence/states.py
+++ b/qadence/states.py
@@ -301,7 +301,7 @@ def random_state(
     ```python exec="on" source="material-block" result="json"
     from qadence.states import random_state, StateGeneratorType
     from qadence.states import random_state, is_normalized, pmf
-    from qadence.backend import BackendName
+    from qadence.types import BackendName
     from torch.distributions import Distribution
 
     ### We have the following options:

--- a/tests/analog/test_analog_emulation.py
+++ b/tests/analog/test_analog_emulation.py
@@ -7,10 +7,12 @@ import pytest
 import torch
 from metrics import JS_ACCEPTANCE
 
-from qadence import QuantumCircuit, QuantumModel, run, sample
 from qadence.analog import add_interaction
 from qadence.blocks.abstract import AbstractBlock
 from qadence.blocks.analog import AnalogBlock
+from qadence.circuit import QuantumCircuit
+from qadence.execution import run, sample
+from qadence.models.quantum_model import QuantumModel
 from qadence.operations import (
     RX,
     RY,

--- a/tests/analog/test_pyq_vs_pulser.py
+++ b/tests/analog/test_pyq_vs_pulser.py
@@ -10,7 +10,7 @@ from metrics import (
     SMALL_SPACING,
 )
 
-from qadence import BackendName, Register, add_interaction
+from qadence.analog.interaction import add_interaction
 from qadence.backends.pulser.devices import Device
 from qadence.blocks import AbstractBlock, chain, kron
 from qadence.circuit import QuantumCircuit
@@ -33,8 +33,9 @@ from qadence.operations import (
     wait,
 )
 from qadence.parameters import FeatureParameter
+from qadence.register import Register
 from qadence.states import equivalent_state, random_state
-from qadence.types import DiffMode
+from qadence.types import BackendName, DiffMode
 
 
 @pytest.mark.flaky(max_runs=5)

--- a/tests/backends/braket/test_quantum_braket.py
+++ b/tests/backends/braket/test_quantum_braket.py
@@ -9,12 +9,12 @@ import torch
 from braket.circuits import Circuit
 from torch import Tensor
 
-from qadence import run
 from qadence.backends import backend_factory
 from qadence.backends.braket import Backend
 from qadence.blocks import AbstractBlock, PrimitiveBlock
 from qadence.circuit import QuantumCircuit
 from qadence.constructors import ising_hamiltonian, single_z, total_magnetization
+from qadence.execution import run
 from qadence.operations import CNOT, CPHASE, CSWAP, RX, RY, RZ, SWAP, H, I, S, T, U, X, Y, Z, chain
 from qadence.states import equivalent_state
 

--- a/tests/backends/pulser_basic/test_configuration.py
+++ b/tests/backends/pulser_basic/test_configuration.py
@@ -7,7 +7,7 @@ from pulser_simulation.simconfig import SimConfig
 
 from qadence import QuantumCircuit
 from qadence.backends.pulser import Backend
-from qadence.blocks import chain
+from qadence.blocks.utils import chain
 from qadence.divergences import js_divergence
 from qadence.operations import RY, entangle
 from qadence.register import Register

--- a/tests/backends/pulser_basic/test_configuration.py
+++ b/tests/backends/pulser_basic/test_configuration.py
@@ -5,9 +5,9 @@ import pytest
 import torch
 from pulser_simulation.simconfig import SimConfig
 
-from qadence import QuantumCircuit
 from qadence.backends.pulser import Backend
 from qadence.blocks.utils import chain
+from qadence.circuit import QuantumCircuit
 from qadence.divergences import js_divergence
 from qadence.operations import RY, entangle
 from qadence.register import Register

--- a/tests/backends/pulser_basic/test_rotations.py
+++ b/tests/backends/pulser_basic/test_rotations.py
@@ -6,12 +6,13 @@ import pytest
 import torch
 from metrics import JS_ACCEPTANCE
 
-from qadence import BackendName, QuantumCircuit, QuantumModel
 from qadence.blocks import AbstractBlock, chain
+from qadence.circuit import QuantumCircuit
 from qadence.divergences import js_divergence
+from qadence.models import QuantumModel
 from qadence.operations import RX, RY, AnalogRX, AnalogRY
 from qadence.register import Register
-from qadence.types import DiffMode
+from qadence.types import BackendName, DiffMode
 
 
 @pytest.mark.parametrize(

--- a/tests/backends/pyq/test_quantum_pyq.py
+++ b/tests/backends/pyq/test_quantum_pyq.py
@@ -16,7 +16,6 @@ from pyqtorch.circuit import QuantumCircuit as PyQQuantumCircuit
 from sympy import acos
 from torch import Tensor
 
-from qadence import BackendName, DiffMode
 from qadence.backends import backend_factory
 from qadence.backends.pyqtorch.backend import Backend
 from qadence.backends.pyqtorch.config import Configuration as PyqConfig
@@ -59,6 +58,7 @@ from qadence.operations import (
 )
 from qadence.parameters import FeatureParameter, Parameter
 from qadence.transpile import set_trainable
+from qadence.types import BackendName, DiffMode
 
 
 def custom_obs() -> AbstractBlock:

--- a/tests/backends/test_endianness.py
+++ b/tests/backends/test_endianness.py
@@ -10,7 +10,6 @@ from metrics import ATOL_DICT, JS_ACCEPTANCE  # type: ignore
 from torch import Tensor, allclose, pi, tensor
 
 from qadence import QuantumCircuit, block_to_tensor, run, sample
-from qadence.backend import BackendName
 from qadence.backends.api import backend_factory
 from qadence.blocks import AbstractBlock, MatrixBlock, chain, kron
 from qadence.divergences import js_divergence
@@ -19,7 +18,7 @@ from qadence.operations import CNOT, RX, RY, H, HamEvo, I, X, Z
 from qadence.register import Register
 from qadence.states import equivalent_state, product_state
 from qadence.transpile import invert_endianness
-from qadence.types import Endianness, ResultType
+from qadence.types import BackendName, Endianness, ResultType
 from qadence.utils import (
     basis_to_int,
     nqubits_to_basis,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,8 @@ from openfermion import QubitOperator
 from pytest import fixture  # type: ignore
 from sympy import Expr
 
-from qadence import BackendName, DiffMode
-from qadence.blocks import AbstractBlock, chain, kron
-from qadence.blocks.utils import unroll_block_with_scaling
+from qadence.blocks.abstract import AbstractBlock
+from qadence.blocks.utils import chain, kron, unroll_block_with_scaling
 from qadence.circuit import QuantumCircuit
 from qadence.constructors import feature_map, hea, total_magnetization
 from qadence.ml_tools.models import TransformedModule
@@ -18,6 +17,7 @@ from qadence.models import QNN, QuantumModel
 from qadence.operations import CNOT, RX, RY, X, Y, Z
 from qadence.parameters import Parameter
 from qadence.register import Register
+from qadence.types import BackendName, DiffMode
 
 BASIC_NQUBITS = 4
 FM_NQUBITS = 2

--- a/tests/metrics.py
+++ b/tests/metrics.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from qadence import BackendName
+from qadence.types import BackendName
 
 ATOL_64 = 1e-14  # 64 bit precision
 ATOL_32 = 1e-07  # 32 bit precision

--- a/tests/ml_tools/test_model_parameters.py
+++ b/tests/ml_tools/test_model_parameters.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import torch
 
-from qadence import BackendName, DiffMode, QuantumCircuit
+from qadence.circuit import QuantumCircuit
 from qadence.constructors import feature_map, hea, total_magnetization
 from qadence.ml_tools.parameters import get_parameters, num_parameters, set_parameters
 from qadence.models import QNN
+from qadence.types import BackendName, DiffMode
 
 
 def test_get_parameters(Basic: torch.nn.Module) -> None:

--- a/tests/models/test_qnn.py
+++ b/tests/models/test_qnn.py
@@ -6,17 +6,18 @@ import numpy as np
 import pytest
 import torch
 
-from qadence import BackendName, DiffMode, FeatureParameter, QuantumCircuit
 from qadence.blocks import (
     chain,
     kron,
     tag,
 )
+from qadence.circuit import QuantumCircuit
 from qadence.constructors import hea, ising_hamiltonian, total_magnetization
 from qadence.models import QNN
 from qadence.operations import RX, RY
-from qadence.parameters import Parameter
+from qadence.parameters import FeatureParameter, Parameter
 from qadence.states import uniform_state
+from qadence.types import BackendName, DiffMode
 
 
 def build_circuit(n_qubits_per_feature: int, n_features: int, depth: int = 2) -> QuantumCircuit:

--- a/tests/models/test_quantum_model.py
+++ b/tests/models/test_quantum_model.py
@@ -16,7 +16,6 @@ from qadence.circuit import QuantumCircuit
 from qadence.constructors import hea, total_magnetization
 from qadence.divergences import js_divergence
 from qadence.ml_tools.utils import rand_featureparameters
-from qadence.models import QuantumModel
 from qadence.models.quantum_model import QuantumModel
 from qadence.operations import MCRX, RX, HamEvo, I, Toffoli, X, Z
 from qadence.parameters import FeatureParameter, VariationalParameter

--- a/tests/models/test_quantum_model.py
+++ b/tests/models/test_quantum_model.py
@@ -11,15 +11,17 @@ import torch
 from hypothesis import given, settings
 from metrics import ATOL_DICT, JS_ACCEPTANCE  # type: ignore
 
-from qadence import BackendName, DiffMode, FeatureParameter, QuantumCircuit, VariationalParameter
 from qadence.blocks import AbstractBlock, chain, kron
+from qadence.circuit import QuantumCircuit
 from qadence.constructors import hea, total_magnetization
 from qadence.divergences import js_divergence
 from qadence.ml_tools.utils import rand_featureparameters
 from qadence.models.quantum_model import QuantumModel
 from qadence.operations import MCRX, RX, HamEvo, I, Toffoli, X, Z
+from qadence.parameters import FeatureParameter, VariationalParameter
 from qadence.states import equivalent_state
 from qadence.transpile import invert_endianness
+from qadence.types import BackendName, DiffMode
 
 np.random.seed(42)
 torch.manual_seed(42)

--- a/tests/models/test_quantum_model.py
+++ b/tests/models/test_quantum_model.py
@@ -16,6 +16,7 @@ from qadence.circuit import QuantumCircuit
 from qadence.constructors import hea, total_magnetization
 from qadence.divergences import js_divergence
 from qadence.ml_tools.utils import rand_featureparameters
+from qadence.models import QuantumModel
 from qadence.models.quantum_model import QuantumModel
 from qadence.operations import MCRX, RX, HamEvo, I, Toffoli, X, Z
 from qadence.parameters import FeatureParameter, VariationalParameter
@@ -144,11 +145,6 @@ def test_expectation_for_different_backends(circuit: QuantumCircuit) -> None:
 
 
 def test_negative_scale_qm() -> None:
-    from qadence.blocks import kron
-    from qadence.circuit import QuantumCircuit
-    from qadence.models import QuantumModel
-    from qadence.operations import HamEvo, Z
-
     hamilt = kron(Z(0), Z(1)) - 10 * Z(0)
     circ = QuantumCircuit(2, HamEvo(hamilt, 3))
     model = QuantumModel(circ, backend=BackendName.PYQTORCH, diff_mode=DiffMode.AD)
@@ -169,11 +165,6 @@ def test_save_load_qm_pyq(BasicQuantumModel: QuantumModel, tmp_path: Path) -> No
 
 
 def test_hamevo_qm() -> None:
-    from qadence.circuit import QuantumCircuit
-    from qadence.models import QuantumModel
-    from qadence.operations import HamEvo, X, Z
-    from qadence.parameters import VariationalParameter
-
     obs = [Z(0) for _ in range(np.random.randint(1, 4))]
     block = HamEvo(VariationalParameter("theta") * X(1), 1, (0, 1))
     circ = QuantumCircuit(2, block)
@@ -189,10 +180,6 @@ def test_hamevo_qm() -> None:
     ],
 )
 def test_correct_order(backend: BackendName) -> None:
-    from qadence.circuit import QuantumCircuit
-    from qadence.models import QuantumModel
-    from qadence.operations import X, Z
-
     circ = QuantumCircuit(3, X(0))
     obs = [Z(0) for _ in range(np.random.randint(1, 5))]
     n_obs = len(obs)

--- a/tests/qadence/test_dagger.py
+++ b/tests/qadence/test_dagger.py
@@ -7,9 +7,9 @@ import strategies as st
 from hypothesis import given, settings
 from sympy import acos
 
-from qadence import Parameter, QuantumCircuit
-from qadence.blocks import AbstractBlock, chain, kron
-from qadence.blocks.utils import assert_same_block, put
+from qadence.blocks.abstract import AbstractBlock
+from qadence.blocks.utils import assert_same_block, chain, kron, put
+from qadence.circuit import QuantumCircuit
 from qadence.constructors import hea
 from qadence.operations import (
     CNOT,
@@ -38,6 +38,7 @@ from qadence.operations import (
     Z,
     Zero,
 )
+from qadence.parameters import Parameter
 
 
 @pytest.mark.parametrize(

--- a/tests/qadence/test_decompose.py
+++ b/tests/qadence/test_decompose.py
@@ -9,7 +9,6 @@ import pytest
 import torch
 from metrics import ATOL_32, DIGITAL_DECOMP_ACCEPTANCE_HIGH, DIGITAL_DECOMP_ACCEPTANCE_LOW
 
-from qadence import BackendName, DiffMode
 from qadence.blocks import (
     AbstractBlock,
     add,
@@ -37,7 +36,7 @@ from qadence.operations import (
 )
 from qadence.parameters import Parameter, VariationalParameter, evaluate
 from qadence.serialization import deserialize
-from qadence.types import LTSOrder
+from qadence.types import BackendName, DiffMode, LTSOrder
 
 
 @no_type_check

--- a/tests/qadence/test_matrixblock.py
+++ b/tests/qadence/test_matrixblock.py
@@ -5,7 +5,6 @@ import pytest
 import torch
 
 from qadence import QuantumCircuit as QC
-from qadence.backend import BackendName
 from qadence.backends.api import DiffMode
 from qadence.blocks import MatrixBlock, ParametricBlock, PrimitiveBlock, chain
 from qadence.blocks.block_to_tensor import OPERATIONS_DICT, block_to_tensor
@@ -14,6 +13,7 @@ from qadence.execution import run
 from qadence.models import QuantumModel as QM
 from qadence.operations import CNOT, RX, RY, RZ, H, I, S, T, U, X, Y, Z
 from qadence.states import random_state
+from qadence.types import BackendName
 
 
 @pytest.mark.parametrize("gate", [I, X, Y, Z, H, T, S])

--- a/tests/qadence/test_matrixblock.py
+++ b/tests/qadence/test_matrixblock.py
@@ -4,10 +4,10 @@ import numpy as np
 import pytest
 import torch
 
-from qadence import QuantumCircuit as QC
 from qadence.backends.api import DiffMode
 from qadence.blocks import MatrixBlock, ParametricBlock, PrimitiveBlock, chain
 from qadence.blocks.block_to_tensor import OPERATIONS_DICT, block_to_tensor
+from qadence.circuit import QuantumCircuit as QC
 from qadence.constructors import hea
 from qadence.execution import run
 from qadence.models import QuantumModel as QM

--- a/tests/qadence/test_measurements/test_shadows.py
+++ b/tests/qadence/test_measurements/test_shadows.py
@@ -8,19 +8,13 @@ import pytest
 import torch
 from torch import Tensor
 
-from qadence import (
-    BackendName,
-    DiffMode,
-    Parameter,
-    QuantumCircuit,
-    QuantumModel,
-    backend_factory,
-    expectation,
-)
+from qadence.backends.api import backend_factory
 from qadence.blocks.abstract import AbstractBlock
 from qadence.blocks.block_to_tensor import IMAT
 from qadence.blocks.utils import add, chain, kron
+from qadence.circuit import QuantumCircuit
 from qadence.constructors import ising_hamiltonian, total_magnetization
+from qadence.execution import expectation
 from qadence.measurements import Measurements
 from qadence.measurements.shadow import (
     PROJECTOR_MATRICES,
@@ -32,8 +26,11 @@ from qadence.measurements.shadow import (
     local_shadow,
     number_of_samples,
 )
+from qadence.models.quantum_model import QuantumModel
 from qadence.operations import RX, RY, H, I, X, Y, Z
+from qadence.parameters import Parameter
 from qadence.serialization import deserialize
+from qadence.types import BackendName, DiffMode
 
 
 @pytest.mark.parametrize(

--- a/tests/qadence/test_measurements/test_shadows.py
+++ b/tests/qadence/test_measurements/test_shadows.py
@@ -17,8 +17,9 @@ from qadence import (
     backend_factory,
     expectation,
 )
-from qadence.blocks import AbstractBlock
+from qadence.blocks.abstract import AbstractBlock
 from qadence.blocks.block_to_tensor import IMAT
+from qadence.blocks.utils import add, chain, kron
 from qadence.constructors import ising_hamiltonian, total_magnetization
 from qadence.measurements import Measurements
 from qadence.measurements.shadow import (
@@ -31,7 +32,7 @@ from qadence.measurements.shadow import (
     local_shadow,
     number_of_samples,
 )
-from qadence.operations import RX, RY, H, I, X, Y, Z, add, chain, kron
+from qadence.operations import RX, RY, H, I, X, Y, Z
 from qadence.serialization import deserialize
 
 

--- a/tests/qadence/test_measurements/test_tomography.py
+++ b/tests/qadence/test_measurements/test_tomography.py
@@ -9,7 +9,6 @@ import torch
 from hypothesis import given, settings
 from metrics import HIGH_ACCEPTANCE, LOW_ACCEPTANCE, MIDDLE_ACCEPTANCE  # type: ignore
 
-from qadence import BackendName, BasisSet, DiffMode
 from qadence.backends import backend_factory
 from qadence.blocks import (
     AbstractBlock,
@@ -40,6 +39,7 @@ from qadence.ml_tools.utils import rand_featureparameters
 from qadence.models import QNN, QuantumModel
 from qadence.operations import RX, RY, H, SDagger, X, Y, Z
 from qadence.parameters import Parameter
+from qadence.types import BackendName, BasisSet, DiffMode
 
 torch.manual_seed(1)
 

--- a/tests/qadence/test_observable.py
+++ b/tests/qadence/test_observable.py
@@ -4,7 +4,6 @@ import strategies as st  # type: ignore
 import torch
 from hypothesis import given, settings
 
-from qadence import block_to_tensor, total_magnetization
 from qadence.blocks import (
     AbstractBlock,
     AddBlock,
@@ -12,6 +11,8 @@ from qadence.blocks import (
     add,
     kron,
 )
+from qadence.blocks.block_to_tensor import block_to_tensor
+from qadence.constructors import total_magnetization
 from qadence.operations import X, Y, Z
 from qadence.parameters import VariationalParameter
 from qadence.serialization import deserialize

--- a/tests/qadence/test_operators.py
+++ b/tests/qadence/test_operators.py
@@ -6,7 +6,6 @@ import torch
 from openfermion import QubitOperator, get_sparse_operator
 from torch.linalg import eigvals
 
-from qadence import block_to_tensor
 from qadence.blocks import (
     AbstractBlock,
     AddBlock,
@@ -17,6 +16,7 @@ from qadence.blocks import (
     kron,
     to_openfermion,
 )
+from qadence.blocks.block_to_tensor import block_to_tensor
 from qadence.operations import (
     CNOT,
     CPHASE,

--- a/tests/qadence/test_overlap.py
+++ b/tests/qadence/test_overlap.py
@@ -7,12 +7,14 @@ import pytest
 import torch
 from metrics import LOW_ACCEPTANCE
 
-from qadence import BackendName, Overlap, OverlapMethod, QuantumCircuit, backend_factory
+from qadence.backends.api import backend_factory
 from qadence.blocks import chain, kron, tag
 from qadence.blocks.primitive import PrimitiveBlock
+from qadence.circuit import QuantumCircuit
 from qadence.operations import RX, RY, H, I, S, T, Z
+from qadence.overlap import Overlap, OverlapMethod
 from qadence.parameters import FeatureParameter, VariationalParameter
-from qadence.types import DiffMode
+from qadence.types import BackendName, DiffMode
 
 torch.manual_seed(42)
 

--- a/tests/qadence/test_parameters.py
+++ b/tests/qadence/test_parameters.py
@@ -6,7 +6,6 @@ import sympy
 import torch
 from torch import allclose
 
-from qadence import BackendName, DiffMode
 from qadence.backends.pyqtorch import Backend as PyQBackend
 from qadence.blocks import ParametricBlock, chain
 from qadence.blocks.utils import expressions
@@ -22,6 +21,7 @@ from qadence.parameters import (
 )
 from qadence.serialization import deserialize, serialize
 from qadence.states import one_state, uniform_state, zero_state
+from qadence.types import BackendName, DiffMode
 
 
 def test_param_initialization(parametric_circuit: QuantumCircuit) -> None:

--- a/tests/qadence/test_register.py
+++ b/tests/qadence/test_register.py
@@ -7,7 +7,7 @@ import networkx as nx
 import numpy as np
 from pytest import approx
 
-from qadence import Register
+from qadence.register import Register
 
 
 def calc_dist(graph: nx.Graph) -> np.ndarray:

--- a/tests/qadence/test_transpile.py
+++ b/tests/qadence/test_transpile.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from qadence import chain, kron
 from qadence.blocks import AbstractBlock, AddBlock, ChainBlock, KronBlock
+from qadence.blocks.utils import chain, kron
 from qadence.operations import RX, RZ, H, HamEvo, X
 from qadence.transpile import chain_single_qubit_ops, digitalize, flatten
 from qadence.types import LTSOrder

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -11,7 +11,6 @@ from numpy import pi
 from sympy import Basic, Expr, acos, asin, atan, cos, sin, tan
 from torch import Tensor
 
-from qadence.backend import BackendName
 from qadence.blocks import (
     AbstractBlock,
     ParametricBlock,
@@ -32,7 +31,7 @@ from qadence.operations import (
     two_qubit_gateset,
 )
 from qadence.parameters import FeatureParameter, Parameter, VariationalParameter
-from qadence.types import ParameterType, TNumber
+from qadence.types import BackendName, ParameterType, TNumber
 
 PARAM_NAME_LENGTH = 1
 MIN_SYMBOLS = 1

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -9,12 +9,11 @@ from metrics import JS_ACCEPTANCE  # type: ignore
 from torch import Tensor, allclose, rand
 
 from qadence import RX, QuantumCircuit, Z, expectation, run, sample, total_magnetization
-from qadence.backend import BackendName
 from qadence.blocks import AbstractBlock
 from qadence.divergences import js_divergence
 from qadence.register import Register
 from qadence.states import equivalent_state
-from qadence.types import DiffMode
+from qadence.types import BackendName, DiffMode
 
 BACKENDS = [BackendName.PYQTORCH, BackendName.BRAKET]
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -8,9 +8,12 @@ from hypothesis import given, settings
 from metrics import JS_ACCEPTANCE  # type: ignore
 from torch import Tensor, allclose, rand
 
-from qadence import RX, QuantumCircuit, Z, expectation, run, sample, total_magnetization
 from qadence.blocks import AbstractBlock
+from qadence.circuit import QuantumCircuit
+from qadence.constructors import total_magnetization
 from qadence.divergences import js_divergence
+from qadence.execution import expectation, run, sample
+from qadence.operations import RX, Z
 from qadence.register import Register
 from qadence.states import equivalent_state
 from qadence.types import BackendName, DiffMode


### PR DESCRIPTION
Circular imports keep generating issues when developing within qadence. this is often due to wrong imports, for example importing from the global qadence modules or importing modules through other files where the requested module is also imported. this MR fixes many of these issues