### PR TITLE
[Feature] Add coords scaling and distance calculation directly to Register

### DIFF
--- a/docs/digital_analog_qc/analog-basics.md
+++ b/docs/digital_analog_qc/analog-basics.md
@@ -160,13 +160,6 @@ operation with the added qubit interactions, as shown explicitly in the
 minimized section above. However, this operation is also supported in the
 Pulser backend, where the correct pulses are automatically created.
 
-!!! warning
-    When using the Pulser backend it is currently advised to always explicitly pass
-    the register spacing in the `configuration` dictionary, which is a constant that
-    multiplies the coordinates of the register. The passing of register spacing
-    between PyQTorch and Pulser backends is currently inconsistent, and will soon be unified.
-    By disregarding it in PyQTorch and setting it to 1 in Pulser, results should be consistent.
-
 
 ```python exec="on" source="material-block" result="json" session="emu"
 
@@ -174,7 +167,6 @@ wf = run(
     reg,
     rot_op,
     backend = BackendName.PULSER,
-    configuration = {"spacing": 1.0}  # Ensures the register is not re-scaled
 )
 
 print(wf)
@@ -268,7 +260,6 @@ wf_analog_pulser = run(
     rot_analog,
     state = init_state,
     backend = BackendName.PULSER,
-    configuration = {"spacing": 1.0}
 )
 
 bool_equiv = equivalent_state(wf_analog_pyq, wf_analog_pulser, atol = 1e-03)
@@ -295,7 +286,7 @@ op = wait(duration = duration)
 init_state = random_state(n_qubits)
 
 wf_pyq = run(reg, op, state = init_state, backend = BackendName.PYQTORCH)
-wf_pulser = run(reg, op, state = init_state, backend = BackendName.PULSER, configuration = {"spacing": 1.0})
+wf_pulser = run(reg, op, state = init_state, backend = BackendName.PULSER)
 
 bool_equiv = equivalent_state(wf_pyq, wf_pulser, atol = 1e-03)
 

--- a/docs/digital_analog_qc/pulser-basic.md
+++ b/docs/digital_analog_qc/pulser-basic.md
@@ -1,7 +1,8 @@
 Qadence offers a direct interface with Pulser[^1], an open-source pulse-level interface written in Python and
 specifically designed for programming neutral atom quantum computers.
 
-Using directly Pulser requires advanced knowledge on pulse-level programming and on how neutral atom devices work. Qadence abstracts this complexity out by using the familiar block-based interface for building pulse sequences in Pulser while leaving the possibility
+Using directly Pulser requires advanced knowledge on pulse-level programming and on how neutral atom devices work. Qadence
+abstracts this complexity out by using the familiar block-based interface for building pulse sequences in Pulser while leaving the possibility
 to directly manipulate them if required by, for instance, optimal pulse shaping.
 
 !!! note
@@ -13,7 +14,7 @@ to directly manipulate them if required by, for instance, optimal pulse shaping.
     cloud platform. In order to do so, make to have valid credentials for the PASQAL cloud platform and use
     the following configuration for the Pulser backend:
 
-    ```python exec="off" source="material-block" html="1" session="pulser-basic"
+    ```python
     config = {
         "cloud_configuration": {
             "username": "<changeme>",
@@ -82,12 +83,12 @@ import torch
 import matplotlib.pyplot as plt
 from qadence import Register, QuantumCircuit, QuantumModel
 
-register = Register(2)
+register = Register.line(2, scale = 8.0)  # Two qubits with a distance of 8µm
 circuit = QuantumCircuit(register, bell_state)
 model = QuantumModel(circuit, backend="pulser", diff_mode="gpsr")
 
 params = {
-    "t": torch.tensor([383]),  # ns
+    "t": torch.tensor([1000]),  # ns
     "y": torch.tensor([3*torch.pi/2]),
 }
 
@@ -141,7 +142,7 @@ One can use the `Configuration` of the Pulser backend to select the appropriate 
 from qadence import BackendName, DiffMode
 from qadence.backends.pulser.devices import Device
 
-register = Register(2)
+register = Register.line(2, scale = 8.0)
 circuit = QuantumCircuit(register, bell_state)
 
 # Choose a realistic device
@@ -153,7 +154,7 @@ model = QuantumModel(
 )
 
 params = {
-    "t": torch.tensor([383]),  # ns
+    "t": torch.tensor([1000]),  # ns
     "y": torch.tensor([3*torch.pi/2]),
 }
 
@@ -186,12 +187,12 @@ protocol = chain(
    RY(0, "y"),
 )
 
-register = Register(2)
+register = Register.line(2, scale = 8.0)
 circuit = QuantumCircuit(register, protocol)
 model = QuantumModel(circuit, backend=BackendName.PULSER, diff_mode=DiffMode.GPSR)
 
 params = {
-    "t": torch.tensor([383]),  # ns
+    "t": torch.tensor([500]),  # ns
     "y": torch.tensor([torch.pi / 2]),
 }
 
@@ -228,7 +229,7 @@ protocol = chain(
     AnalogRX(torch.pi/4)
 )
 
-register = Register(2)
+register = Register.line(2, scale=8.0)
 circuit = QuantumCircuit(register, protocol)
 model = QuantumModel(circuit, backend=BackendName.PULSER, diff_mode=DiffMode.GPSR)
 

--- a/docs/digital_analog_qc/pulser-basic.md
+++ b/docs/digital_analog_qc/pulser-basic.md
@@ -83,7 +83,7 @@ import torch
 import matplotlib.pyplot as plt
 from qadence import Register, QuantumCircuit, QuantumModel
 
-register = Register.line(2, scale = 8.0)  # Two qubits with a distance of 8µm
+register = Register.line(2, spacing = 8.0)  # Two qubits with a distance of 8µm
 circuit = QuantumCircuit(register, bell_state)
 model = QuantumModel(circuit, backend="pulser", diff_mode="gpsr")
 
@@ -142,7 +142,7 @@ One can use the `Configuration` of the Pulser backend to select the appropriate 
 from qadence import BackendName, DiffMode
 from qadence.backends.pulser.devices import Device
 
-register = Register.line(2, scale = 8.0)
+register = Register.line(2, spacing = 8.0)
 circuit = QuantumCircuit(register, bell_state)
 
 # Choose a realistic device
@@ -187,7 +187,7 @@ protocol = chain(
    RY(0, "y"),
 )
 
-register = Register.line(2, scale = 8.0)
+register = Register.line(2, spacing = 8.0)
 circuit = QuantumCircuit(register, protocol)
 model = QuantumModel(circuit, backend=BackendName.PULSER, diff_mode=DiffMode.GPSR)
 
@@ -229,7 +229,7 @@ protocol = chain(
     AnalogRX(torch.pi/4)
 )
 
-register = Register.line(2, scale=8.0)
+register = Register.line(2, spacing=8.0)
 circuit = QuantumCircuit(register, protocol)
 model = QuantumModel(circuit, backend=BackendName.PULSER, diff_mode=DiffMode.GPSR)
 

--- a/docs/tutorials/hamiltonians.md
+++ b/docs/tutorials/hamiltonians.md
@@ -44,7 +44,7 @@ print(hamilt) # markdown-exec: hide
 !!! warning "Ordering interaction strengths matters"
 
 	When passing interaction strengths as an array, the ordering must be identical to the one
-	obtained from the `edge` property of a Qadence [`Register`](register.md):
+	obtained from the `edges` property of a Qadence [`Register`](register.md):
 
 	```python exec="on" source="material-block" result="json" session="hamiltonians"
 	from qadence import Register

--- a/docs/tutorials/register.md
+++ b/docs/tutorials/register.md
@@ -53,23 +53,74 @@ print(docsutils.fig_to_html(fig)) # markdown-exec: hide
 
 Built-in topologies are directly accessible in the `Register`:
 
-```python exec="on" source="material-block" html="1"
+```python exec="on" source="material-block" html="1" session="register"
+from docs import docsutils # markdown-exec: hide
+import matplotlib.pyplot as plt # markdown-exec: hide
 from qadence import Register
 
-reg = Register.honeycomb_lattice(2, 3)
-import matplotlib.pyplot as plt # markdown-exec: hide
-plt.clf() # markdown-exec: hide
-reg.draw(show=False)
-from docs import docsutils # markdown-exec: hide
-fig = plt.gcf() # markdown-exec: hide
-fig.set_size_inches(3, 3) # markdown-exec: hide
-print(docsutils.fig_to_html(plt.gcf())) # markdown-exec: hide
+reg = Register.all_to_all(n_qubits = 2)
+reg_line = Register.line(n_qubits = 2)
+reg_circle = Register.circle(n_qubits = 2)
+reg_squre = Register.square(qubits_side = 2)
+reg_rect = Register.rectangular_lattice(qubits_row = 2, qubits_col = 2)
+reg_triang = Register.triangular_lattice(n_cells_row = 2, n_cells_col = 2)
+reg_honey = Register.honeycomb_lattice(n_cells_row = 2, n_cells_col = 2)
 ```
 
-Arbitrarily shaped registers can be constructed by providing coordinates.
+Qubit coordinates are saved as node properties in the underlying NetworkX graph, but can
+be accessed directly with the `coords` property.
 
-!!! note "Registers defined from coordinates"
-	`Register` constructed via the `from_coordinates` method do not define edges in the connectivity graph.
+```python exec="on" source="material-block" result="json" session="register"
+reg = Register.square(2)
+print(reg.coords)
+```
+
+Register coordinates can be re-scaled with the `rescale_coords` method, or a `scale` can be
+passed directly as an optional argument at register creation.
+
+```python exec="on" source="material-block" result="json" session="register"
+scaled_reg_1 = reg.rescale_coords(scale = 2.0)
+scaled_reg_2 = Register.square(2, scale = 2.0)
+print(scaled_reg_1.coords)
+print(scaled_reg_2.coords)
+```
+
+The distance between qubits can also be directly accessed with the `distances` and `all_distances`
+properties.
+
+```python exec="on" source="material-block" result="json" session="register"
+print("Distance between qubits connected by an edge:")  # markdown-exec: hide
+print(reg.distances)
+print("Distance between all qubit pairs in the graph")  # markdown-exec: hide
+print(reg.all_distances)
+```
+
+By calling the `Register` directly, either the number of nodes or a specific graph can be given as input.
+If passing a custom graph directly, the node positions will not be defined automatically, and should be
+previously saved in the `"pos"` node property. If not, `reg.coords` will return empty tuples and all
+distances will be 0.
+
+```python exec="on" source="material-block" result="json" session="register"
+import networkx as nx
+
+# Same as Register.all_to_all(n_qubits = 2):
+reg = Register(2)
+
+# Register from a custom graph:
+graph = nx.complete_graph(3)
+
+# Set node positions, in this case a simple line:
+for i, node in enumerate(graph.nodes):
+    graph.nodes[node]["pos"] = (1.0 * i, 0.0)
+
+reg = Register(graph)
+
+print(reg.distances)
+```
+
+
+Alternatively, arbitrarily shaped registers can also be constructed by providing the node coordinates.
+In this case, there will be no edges automatically created in the connectivity graph.
 
 ```python exec="on" source="material-block" html="1"
 import numpy as np
@@ -82,7 +133,7 @@ reg = Register.from_coordinates(
 import matplotlib.pyplot as plt # markdown-exec: hide
 plt.clf() # markdown-exec: hide
 fig = plt.gcf() # markdown-exec: hide
-fig.set_size_inches(4, 2) # markdown-exec: hide
+fig.set_size_inches(2*np.pi, 2.5) # markdown-exec: hide
 plt.tight_layout() # markdown-exec: hide
 reg.draw(show=False)
 from docs import docsutils # markdown-exec: hide
@@ -91,10 +142,10 @@ print(docsutils.fig_to_html(fig)) # markdown-exec: hide
 
 !!! warning "Units for qubit coordinates"
     In general, Qadence makes no assumption about the units given to qubit coordinates.
-    However, if used in the context of a Hamiltonian coefficient, the quantity $H.t$
-    must be **dimensionless** for exponentiation in the PyQTorch backend, where it is assumed that $\hbar = 1$
-    (consistent ).
+    However, if used in the context of a Hamiltonian coefficient, care should be taken by the user to guarantee the
+    quantity $H.t$ is **dimensionless** for exponentiation in the PyQTorch backend, where it is assumed that $\hbar = 1$.
 	For registers passed to the [Pulser](https://github.com/pasqal-io/Pulser) backend, coordinates are in $\mu \textrm{m}$.
+
 
 ## Connectivity graphs
 
@@ -114,11 +165,10 @@ print(f"{reg.nodes = }") # markdown-exec: hide
 print(f"{reg.edges = }") # markdown-exec: hide
 ```
 
-It is possible to customize qubit interaction through the `add_interaction` method.
-In that case, `Register.coords` are accessible from the concrete graph:
+Just like the property `all_distances`, there is also an `all_edges` property for convencience:
 
 ```python exec="on" source="material-block" result="json" session="reg-usage"
-print(f"{reg.coords = }")
+print(reg.all_edges)
 ```
 
-More details about their usage in the digital-analog paradigm can be found in the [digital-analog basics](../digital_analog_qc/analog-basics.md) section.
+More details about the usage of Registers in the digital-analog paradigm can be found in the [digital-analog basics](../digital_analog_qc/analog-basics.md) section.

--- a/docs/tutorials/register.md
+++ b/docs/tutorials/register.md
@@ -51,7 +51,7 @@ print(docsutils.fig_to_html(fig)) # markdown-exec: hide
 
 ## Building and drawing registers
 
-Built-in topologies are directly accessible in the `Register`:
+Built-in topologies are directly accessible in the `Register` methods:
 
 ```python exec="on" source="material-block" html="1" session="register"
 from docs import docsutils # markdown-exec: hide
@@ -74,25 +74,26 @@ be accessed directly with the `coords` property.
 reg = Register.square(2)
 print(reg.coords)
 ```
-
-Register coordinates can be re-scaled with the `rescale_coords` method, or a `scale` can be
-passed directly as an optional argument at register creation.
+By default, the coords are scaled such that the minimum distance between any two qubits is 1,
+unless the register is created directly from specific coordinates as shown below. The `spacing`
+argument can be used to set the minimum spacing. The `rescale_coords` method can be used to create
+a new register by rescaling the coordinates of an already created register.
 
 ```python exec="on" source="material-block" result="json" session="register"
-scaled_reg_1 = reg.rescale_coords(scale = 2.0)
-scaled_reg_2 = Register.square(2, scale = 2.0)
+scaled_reg_1 = Register.square(2, spacing = 2.0)
+scaled_reg_2 = reg.rescale_coords(scaling = 2.0)
 print(scaled_reg_1.coords)
 print(scaled_reg_2.coords)
 ```
 
-The distance between qubits can also be directly accessed with the `distances` and `all_distances`
+The distance between qubits can also be directly accessed with the `distances` and `edge_distances`
 properties.
 
 ```python exec="on" source="material-block" result="json" session="register"
-print("Distance between qubits connected by an edge:")  # markdown-exec: hide
+print("Distance between all qubit pairs:")  # markdown-exec: hide
 print(reg.distances)
-print("Distance between all qubit pairs in the graph")  # markdown-exec: hide
-print(reg.all_distances)
+print("Distance between qubits connect by an edge in the graph")  # markdown-exec: hide
+print(reg.edge_distances)
 ```
 
 By calling the `Register` directly, either the number of nodes or a specific graph can be given as input.
@@ -141,7 +142,7 @@ print(docsutils.fig_to_html(fig)) # markdown-exec: hide
 ```
 
 !!! warning "Units for qubit coordinates"
-    In general, Qadence makes no assumption about the units given to qubit coordinates.
+    In general, Qadence makes no assumption about the units for qubit coordinates and distances.
     However, if used in the context of a Hamiltonian coefficient, care should be taken by the user to guarantee the
     quantity $H.t$ is **dimensionless** for exponentiation in the PyQTorch backend, where it is assumed that $\hbar = 1$.
 	For registers passed to the [Pulser](https://github.com/pasqal-io/Pulser) backend, coordinates are in $\mu \textrm{m}$.
@@ -165,7 +166,7 @@ print(f"{reg.nodes = }") # markdown-exec: hide
 print(f"{reg.edges = }") # markdown-exec: hide
 ```
 
-Just like the property `all_distances`, there is also an `all_edges` property for convencience:
+There is also an `all_edges` property for convencience:
 
 ```python exec="on" source="material-block" result="json" session="reg-usage"
 print(reg.all_edges)

--- a/qadence/analog/interaction.py
+++ b/qadence/analog/interaction.py
@@ -49,7 +49,6 @@ def add_interaction(
     x: Register | QuantumCircuit | AbstractBlock,
     *args: Any,
     interaction: Interaction | Callable = Interaction.NN,
-    spacing: float = 1.0,
 ) -> QuantumCircuit | AbstractBlock:
     """Turns blocks or circuits into (a chain of) `HamEvo` blocks.
 
@@ -69,7 +68,6 @@ def add_interaction(
             combinations are accepted.
         interaction: Type of interaction that is added. Can also be a function that accepts a
             register and a list of edges that define which qubits interact (see the examples).
-        spacing: All qubit coordinates are multiplied by `spacing`.
 
     Examples:
     ```python exec="on" source="material-block" result="json"
@@ -130,7 +128,6 @@ def _(
     register: Register,
     block: AbstractBlock,
     interaction: Union[Interaction, Callable] = Interaction.NN,
-    spacing: float = 1.0,
 ) -> AbstractBlock:
     try:
         fn = interaction if callable(interaction) else INTERACTIONS[Interaction(interaction)]
@@ -138,8 +135,7 @@ def _(
         raise KeyError(
             "Function `add_interaction` only supports NN and XY, or a custom callable function."
         )
-    reg = register._scale_positions(spacing)
-    return _add_interaction(block, reg, fn)  # type: ignore[arg-type]
+    return _add_interaction(block, register, fn)  # type: ignore[arg-type]
 
 
 @singledispatch

--- a/qadence/backends/pulser/backend.py
+++ b/qadence/backends/pulser/backend.py
@@ -47,16 +47,7 @@ def _convert_init_state(state: Tensor) -> np.ndarray:
 
 
 def create_register(register: Register) -> PulserRegister:
-    """Create Pulser register instance.
-
-    Args:
-        register (Register): graph representing a register with accompanying coordinate data
-
-    Returns:
-        Register: Pulser register
-    """
-
-    # create register from coordinates
+    """Convert Qadence Register to Pulser Register."""
     coords = np.array(list(register.coords.values()))
     return PulserRegister.from_coordinates(coords)
 

--- a/qadence/backends/pulser/config.py
+++ b/qadence/backends/pulser/config.py
@@ -35,9 +35,6 @@ class Configuration(BackendConfiguration):
     amplitude, minimum atom spacing and other properties of the system
     """
 
-    spacing: Optional[float] = None
-    """Atomic spacing for Pulser register."""
-
     sampling_rate: float = 1.0
     """Sampling rate to be used for local simulations.
 

--- a/qadence/backends/pulser/pulses.py
+++ b/qadence/backends/pulser/pulses.py
@@ -47,7 +47,6 @@ def add_pulses(
     block: AbstractBlock,
     config: Configuration,
     qc_register: Register,
-    spacing: float,
 ) -> None:
     # we need this because of the case with a single type of block in a KronBlock
     # TODO: document properly
@@ -98,9 +97,7 @@ def add_pulses(
         d = evaluate(detuning) if detuning.is_number else sequence.declare_variable(d_uuid)
 
         # calculate generator eigenvalues
-        block.eigenvalues_generator = block.compute_eigenvalues_generator(
-            qc_register, block, spacing
-        )
+        block.eigenvalues_generator = block.compute_eigenvalues_generator(qc_register, block)
 
         if block.qubit_support.is_global:
             pulse = analog_rot_pulse(a, w, p, d, global_channel, config)
@@ -131,7 +128,7 @@ def add_pulses(
 
     elif isinstance(block, CompositeBlock) or isinstance(block, AnalogComposite):
         for block in block.blocks:
-            add_pulses(sequence, block, config, qc_register, spacing)
+            add_pulses(sequence, block, config, qc_register)
 
     else:
         msg = f"The pulser backend currently does not support blocks of type: {type(block)}"

--- a/qadence/blocks/analog.py
+++ b/qadence/blocks/analog.py
@@ -83,11 +83,11 @@ class AnalogBlock(AbstractBlock):
         return s
 
     def compute_eigenvalues_generator(
-        self, register: Register, block: AbstractBlock, spacing: float
+        self, register: Register, block: AbstractBlock
     ) -> torch.Tensor:
         from qadence import add_interaction
 
-        return add_interaction(register, block, spacing=spacing).eigenvalues_generator
+        return add_interaction(register, block).eigenvalues_generator
 
 
 @dataclass(eq=False, repr=False)

--- a/qadence/register.py
+++ b/qadence/register.py
@@ -232,6 +232,11 @@ def triangular_lattice_graph(n_cells_row: int, n_cells_col: int) -> nx.Graph:
 
 
 def alltoall_graph(n_qubits: int) -> nx.Graph:
+    if n_qubits == 2:
+        return line_graph(2)
+    if n_qubits == 3:
+        return triangular_lattice_graph(1, 1)
+
     graph = nx.complete_graph(n_qubits)
     # set seed to make sure the produced graphs are reproducible
     coords = nx.spring_layout(graph, seed=0)

--- a/qadence/register.py
+++ b/qadence/register.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from itertools import product
 from typing import Any
 
 import matplotlib.pyplot as plt
@@ -52,6 +53,15 @@ class Register:
 
         if scale != 1.0:
             _scale_node_positions(self.graph, scale)
+
+        # Auxiliary complete graph
+        support = self.graph.nodes
+        all_edges = list(filter(lambda x: x[0] < x[1], product(support, support)))
+        self.complete_graph = nx.Graph()
+        self.complete_graph.add_nodes_from(support)
+        self.complete_graph.add_edges_from(all_edges)
+        pos_values = nx.get_node_attributes(self.graph, "pos")
+        nx.set_node_attributes(self.complete_graph, pos_values, "pos")
 
     @property
     def n_qubits(self) -> int:
@@ -156,6 +166,10 @@ class Register:
     @property
     def edges(self) -> EdgeView:
         return self.graph.edges
+    
+    @property
+    def all_edges(self) -> EdgeView:
+        return self.complete_graph.edges
 
     @property
     def nodes(self) -> NodeView:

--- a/qadence/register.py
+++ b/qadence/register.py
@@ -70,8 +70,8 @@ class Register:
         return cls(graph, scale)
 
     @classmethod
-    def line(cls, n_qubits: int) -> Register:
-        return cls(line_graph(n_qubits))
+    def line(cls, n_qubits: int, scale: float = 1.0) -> Register:
+        return cls(line_graph(n_qubits), scale)
 
     @classmethod
     def circle(cls, n_qubits: int, scale: float = 1.0) -> Register:
@@ -161,7 +161,7 @@ class Register:
     def nodes(self) -> NodeView:
         return self.graph.nodes
 
-    def _scale_positions(self, scale: float) -> Register:
+    def rescale_coords(self, scale: float) -> Register:
         g = deepcopy(self.graph)
         _scale_node_positions(g, scale)
         return Register(g)

--- a/qadence/register.py
+++ b/qadence/register.py
@@ -200,9 +200,10 @@ class Register:
     def nodes(self) -> NodeView:
         return self.graph.nodes
 
-    def rescale_coords(self, spacing: float) -> Register:
+    def rescale_coords(self, scaling: float) -> Register:
         g = deepcopy(self.graph)
-        return Register(g, spacing)
+        _scale_node_positions(g, min_distance=1.0, spacing=scaling)
+        return Register(g, spacing=None)
 
     def _to_dict(self) -> dict:
         return {"graph": nx.node_link_data(self.graph)}

--- a/qadence/register.py
+++ b/qadence/register.py
@@ -61,7 +61,7 @@ class Register:
         self.complete_graph.add_nodes_from(support)
         self.complete_graph.add_edges_from(all_edges)
 
-        if spacing is not None:
+        if spacing is not None and self.min_distance != 0.0:
             _scale_node_positions(self.graph, self.min_distance, spacing)
 
         pos_values = nx.get_node_attributes(self.graph, "pos")

--- a/qadence/register.py
+++ b/qadence/register.py
@@ -193,7 +193,8 @@ class Register:
 
     @property
     def min_distance(self) -> float:
-        value: float = min(self.distances.values())
+        distances = self.distances
+        value: float = min(self.distances.values()) if len(distances) > 0 else 0.0
         return value
 
     @property

--- a/qadence/register.py
+++ b/qadence/register.py
@@ -17,7 +17,7 @@ from qadence.types import LatticeTopology
 __all__ = ["Register"]
 
 
-def _scale_node_positions(graph: nx.Graph, min_distance, spacing: float) -> None:
+def _scale_node_positions(graph: nx.Graph, min_distance: float, spacing: float) -> None:
     scaled_nodes = {}
     scale_factor = spacing / min_distance
     for k, node in graph.nodes.items():
@@ -27,7 +27,7 @@ def _scale_node_positions(graph: nx.Graph, min_distance, spacing: float) -> None
 
 
 class Register:
-    def __init__(self, support: nx.Graph | int, spacing: float = 1.0):
+    def __init__(self, support: nx.Graph | int, spacing: float | None = 1.0):
         """A 2D register of qubits which includes their coordinates.
 
         It is needed for e.g. analog computing.
@@ -61,7 +61,8 @@ class Register:
         self.complete_graph.add_nodes_from(support)
         self.complete_graph.add_edges_from(all_edges)
 
-        _scale_node_positions(self.graph, self.min_distance, spacing)
+        if spacing is not None:
+            _scale_node_positions(self.graph, self.min_distance, spacing)
 
         pos_values = nx.get_node_attributes(self.graph, "pos")
         nx.set_node_attributes(self.complete_graph, pos_values, "pos")
@@ -75,7 +76,7 @@ class Register:
         cls,
         coords: list[tuple],
         lattice: LatticeTopology | str = LatticeTopology.ARBITRARY,
-        spacing: float = 1.0,
+        spacing: float | None = None,
     ) -> Register:
         graph = nx.Graph()
         for i, pos in enumerate(coords):
@@ -183,16 +184,17 @@ class Register:
     @property
     def distances(self) -> dict:
         coords = self.coords
-        return {edge: dist(coords[edge[0]], coords[edge[1]]) for edge in self.edges}
-
-    @property
-    def all_distances(self) -> dict:
-        coords = self.coords
         return {edge: dist(coords[edge[0]], coords[edge[1]]) for edge in self.all_edges}
 
     @property
+    def edge_distances(self) -> dict:
+        coords = self.coords
+        return {edge: dist(coords[edge[0]], coords[edge[1]]) for edge in self.edges}
+
+    @property
     def min_distance(self) -> float:
-        return min(self.all_distances.values())
+        value: float = min(self.distances.values())
+        return value
 
     @property
     def nodes(self) -> NodeView:

--- a/qadence/register.py
+++ b/qadence/register.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from itertools import product
+from math import dist
 from typing import Any
 
 import matplotlib.pyplot as plt
@@ -166,10 +167,20 @@ class Register:
     @property
     def edges(self) -> EdgeView:
         return self.graph.edges
-    
+
     @property
     def all_edges(self) -> EdgeView:
         return self.complete_graph.edges
+
+    @property
+    def distances(self) -> dict:
+        coords = self.coords
+        return {edge: dist(coords[edge[0]], coords[edge[1]]) for edge in self.edges}
+
+    @property
+    def all_distances(self) -> dict:
+        coords = self.coords
+        return {edge: dist(coords[edge[0]], coords[edge[1]]) for edge in self.all_edges}
 
     @property
     def nodes(self) -> NodeView:

--- a/tests/analog/test_analog_emulation.py
+++ b/tests/analog/test_analog_emulation.py
@@ -64,7 +64,8 @@ d = 3.75
     ],
 )
 def test_far_add_interaction(analog: AnalogBlock, digital_fn: Callable, register: Register) -> None:
-    emu_block = add_interaction(register, analog, spacing=8.0)
+    register = register.rescale_coords(scale=8.0)
+    emu_block = add_interaction(register, analog)
     emu_samples = sample(register, emu_block, backend="pyqtorch")[0]  # type: ignore[arg-type]
     pulser_samples = sample(register, analog, backend="pulser")[0]  # type: ignore[arg-type]
     assert js_divergence(pulser_samples, emu_samples) < JS_ACCEPTANCE
@@ -92,8 +93,9 @@ def test_far_add_interaction(analog: AnalogBlock, digital_fn: Callable, register
 @pytest.mark.parametrize("register", [Register.from_coordinates([(0, 5), (5, 5), (5, 0), (0, 0)])])
 @pytest.mark.flaky(max_runs=5)
 def test_close_add_interaction(block: AnalogBlock, register: Register) -> None:
+    register = register.rescale_coords(scale=8.0)
     pulser_samples = sample(register, block, backend="pulser", n_shots=1000)[0]  # type: ignore[arg-type] # noqa: E501
-    emu_block = add_interaction(register, block, spacing=8.0)
+    emu_block = add_interaction(register, block)
     pyqtorch_samples = sample(register, emu_block, backend="pyqtorch", n_shots=1000)[0]  # type: ignore[arg-type] # noqa: E501
     assert js_divergence(pulser_samples, pyqtorch_samples) < JS_ACCEPTANCE
 

--- a/tests/analog/test_analog_emulation.py
+++ b/tests/analog/test_analog_emulation.py
@@ -64,7 +64,7 @@ d = 3.75
     ],
 )
 def test_far_add_interaction(analog: AnalogBlock, digital_fn: Callable, register: Register) -> None:
-    register = register.rescale_coords(scale=8.0)
+    register = register.rescale_coords(scaling=8.0)
     emu_block = add_interaction(register, analog)
     emu_samples = sample(register, emu_block, backend="pyqtorch")[0]  # type: ignore[arg-type]
     pulser_samples = sample(register, analog, backend="pulser")[0]  # type: ignore[arg-type]
@@ -93,7 +93,7 @@ def test_far_add_interaction(analog: AnalogBlock, digital_fn: Callable, register
 @pytest.mark.parametrize("register", [Register.from_coordinates([(0, 5), (5, 5), (5, 0), (0, 0)])])
 @pytest.mark.flaky(max_runs=5)
 def test_close_add_interaction(block: AnalogBlock, register: Register) -> None:
-    register = register.rescale_coords(scale=8.0)
+    register = register.rescale_coords(scaling=8.0)
     pulser_samples = sample(register, block, backend="pulser", n_shots=1000)[0]  # type: ignore[arg-type] # noqa: E501
     emu_block = add_interaction(register, block)
     pyqtorch_samples = sample(register, emu_block, backend="pyqtorch", n_shots=1000)[0]  # type: ignore[arg-type] # noqa: E501

--- a/tests/analog/test_pyq_vs_pulser.py
+++ b/tests/analog/test_pyq_vs_pulser.py
@@ -60,7 +60,7 @@ def test_analog_op_run(n_qubits: int, spacing: float, op: AbstractBlock) -> None
         block = op(t)  # type: ignore [operator]
         values = {"t": 10.0 * (1.0 + torch.rand(batch_size))}
 
-    register = Register.line(n_qubits, scale=spacing)
+    register = Register.line(n_qubits, spacing=spacing)
 
     circuit = QuantumCircuit(register, block)
 
@@ -95,7 +95,7 @@ def test_analog_op_run(n_qubits: int, spacing: float, op: AbstractBlock) -> None
 def test_compatibility_pyqtorch_pulser_entanglement(
     pyqtorch_block: AbstractBlock, pulser_block: AbstractBlock
 ) -> None:
-    register = Register.line(2, scale=8.0)
+    register = Register.line(2, spacing=8.0)
 
     pyqtorch_circuit = QuantumCircuit(register, pyqtorch_block)
     pulser_circuit = QuantumCircuit(register, pulser_block)
@@ -130,7 +130,7 @@ def test_compatibility_pyqtorch_pulser_digital_rot(obs: AbstractBlock) -> None:
     )
     pyqtorch_circuit = QuantumCircuit(n_qubits, block)
 
-    register = Register.line(n_qubits, scale=LARGE_SPACING)
+    register = Register.line(n_qubits, spacing=LARGE_SPACING)
     pulser_circuit = QuantumCircuit(register, block)
 
     model_pyqtorch = QuantumModel(
@@ -183,7 +183,7 @@ def test_compatibility_pyqtorch_pulser_analog_rot(obs: AbstractBlock) -> None:
     b_analog = chain(AnalogRX(phi), AnalogRY(psi))
     pyqtorch_circuit = QuantumCircuit(n_qubits, b_digital)
 
-    register = Register.line(n_qubits, scale=LARGE_SPACING)
+    register = Register.line(n_qubits, spacing=LARGE_SPACING)
     pulser_circuit = QuantumCircuit(register, b_analog)
 
     model_pyqtorch = QuantumModel(
@@ -224,7 +224,7 @@ def test_compatibility_pyqtorch_pulser_analog_rot_int(obs: AbstractBlock) -> Non
     psi = FeatureParameter("psi")
 
     n_qubits = 2
-    register = Register.line(n_qubits)
+    register = Register.line(n_qubits, spacing=8.0)
 
     b_analog = chain(AnalogRX(phi), AnalogRY(psi))
 

--- a/tests/analog/test_pyq_vs_pulser.py
+++ b/tests/analog/test_pyq_vs_pulser.py
@@ -7,10 +7,8 @@ from metrics import (
     ATOL_DICT,
     JS_ACCEPTANCE,
     LARGE_SPACING,
-    SMALL_SPACING,
 )
 
-from qadence.analog.interaction import add_interaction
 from qadence.backends.pulser.devices import Device
 from qadence.blocks import AbstractBlock, chain, kron
 from qadence.circuit import QuantumCircuit
@@ -62,20 +60,16 @@ def test_analog_op_run(n_qubits: int, spacing: float, op: AbstractBlock) -> None
         block = op(t)  # type: ignore [operator]
         values = {"t": 10.0 * (1.0 + torch.rand(batch_size))}
 
-    register = Register.line(n_qubits)
+    register = Register.line(n_qubits, scale=spacing)
+
     circuit = QuantumCircuit(register, block)
 
-    circuit_pyqtorch = add_interaction(circuit, spacing=spacing)
-
-    model_pyqtorch = QuantumModel(circuit_pyqtorch, backend=BackendName.PYQTORCH)
-
-    conf = {"spacing": spacing}
+    model_pyqtorch = QuantumModel(circuit, backend=BackendName.PYQTORCH)
 
     model_pulser = QuantumModel(
         circuit,
         backend=BackendName.PULSER,
         diff_mode=DiffMode.GPSR,
-        configuration=conf,
     )
 
     wf_pyq = model_pyqtorch.run(values=values, state=init_state)
@@ -88,19 +82,24 @@ def test_analog_op_run(n_qubits: int, spacing: float, op: AbstractBlock) -> None
 
 
 @pytest.mark.parametrize(
-    "pyqtorch_circuit,pulser_circuit",
+    "pyqtorch_block, pulser_block",
     [
         # Bell state generation
         (
-            QuantumCircuit(2, chain(H(0), CNOT(0, 1))),
-            QuantumCircuit(2, chain(entangle(1000, qubit_support=(0, 1)), RY(0, 3 * torch.pi / 2))),
+            chain(H(0), CNOT(0, 1)),
+            chain(entangle(1000, qubit_support=(0, 1)), RY(0, 3 * torch.pi / 2)),
         )
     ],
 )
 @pytest.mark.flaky(max_runs=5)
 def test_compatibility_pyqtorch_pulser_entanglement(
-    pyqtorch_circuit: QuantumCircuit, pulser_circuit: QuantumCircuit
+    pyqtorch_block: AbstractBlock, pulser_block: AbstractBlock
 ) -> None:
+    register = Register.line(2, scale=8.0)
+
+    pyqtorch_circuit = QuantumCircuit(register, pyqtorch_block)
+    pulser_circuit = QuantumCircuit(register, pulser_block)
+
     model_pyqtorch = QuantumModel(
         pyqtorch_circuit, backend=BackendName.PYQTORCH, diff_mode=DiffMode.AD
     )
@@ -131,13 +130,14 @@ def test_compatibility_pyqtorch_pulser_digital_rot(obs: AbstractBlock) -> None:
     )
     pyqtorch_circuit = QuantumCircuit(n_qubits, block)
 
-    register = Register.line(n_qubits)
+    register = Register.line(n_qubits, scale=LARGE_SPACING)
     pulser_circuit = QuantumCircuit(register, block)
 
     model_pyqtorch = QuantumModel(
         pyqtorch_circuit, backend=BackendName.PYQTORCH, diff_mode=DiffMode.AD, observable=obs
     )
-    conf = {"spacing": LARGE_SPACING, "amplitude_local": 2 * np.pi, "detuning": 2 * np.pi}
+    conf = {"amplitude_local": 2 * np.pi, "detuning": 2 * np.pi}
+
     model_pulser = QuantumModel(
         pulser_circuit,
         backend=BackendName.PULSER,
@@ -183,19 +183,18 @@ def test_compatibility_pyqtorch_pulser_analog_rot(obs: AbstractBlock) -> None:
     b_analog = chain(AnalogRX(phi), AnalogRY(psi))
     pyqtorch_circuit = QuantumCircuit(n_qubits, b_digital)
 
-    register = Register.line(n_qubits)
+    register = Register.line(n_qubits, scale=LARGE_SPACING)
     pulser_circuit = QuantumCircuit(register, b_analog)
 
     model_pyqtorch = QuantumModel(
         pyqtorch_circuit, backend=BackendName.PYQTORCH, diff_mode=DiffMode.AD, observable=obs
     )
-    conf = {"spacing": LARGE_SPACING}
+
     model_pulser = QuantumModel(
         pulser_circuit,
         backend=BackendName.PULSER,
         observable=obs,
         diff_mode=DiffMode.GPSR,
-        configuration=conf,
     )
 
     batch_size = 5
@@ -228,21 +227,18 @@ def test_compatibility_pyqtorch_pulser_analog_rot_int(obs: AbstractBlock) -> Non
     register = Register.line(n_qubits)
 
     b_analog = chain(AnalogRX(phi), AnalogRY(psi))
-    pyqtorch_circuit = QuantumCircuit(register, b_analog)
-    pyqtorch_circuit = add_interaction(pyqtorch_circuit, spacing=SMALL_SPACING)
 
-    pulser_circuit = QuantumCircuit(register, b_analog)
+    circuit = QuantumCircuit(register, b_analog)
 
     model_pyqtorch = QuantumModel(
-        pyqtorch_circuit, backend=BackendName.PYQTORCH, diff_mode=DiffMode.AD, observable=obs
+        circuit, backend=BackendName.PYQTORCH, diff_mode=DiffMode.AD, observable=obs
     )
-    conf = {"spacing": SMALL_SPACING}
+
     model_pulser = QuantumModel(
-        pulser_circuit,
+        circuit,
         backend=BackendName.PULSER,
         diff_mode=DiffMode.GPSR,
         observable=obs,
-        configuration=conf,
     )
 
     batch_size = 5

--- a/tests/backends/pulser_basic/test_configuration.py
+++ b/tests/backends/pulser_basic/test_configuration.py
@@ -13,6 +13,7 @@ from qadence.operations import RY, entangle
 from qadence.register import Register
 
 SEED = 42
+DEFAULT_SPACING = 8.0
 
 
 def test_configuration() -> None:
@@ -20,7 +21,7 @@ def test_configuration() -> None:
     np.random.seed(SEED)
 
     blocks = chain(entangle(892, qubit_support=(0, 1)), RY(0, torch.pi / 2))
-    register = Register(2)
+    register = Register(2, scale=DEFAULT_SPACING)
     circuit = QuantumCircuit(register, blocks)
 
     # first try the standard execution with default configuration
@@ -49,7 +50,7 @@ def test_configuration_as_dict() -> None:
     np.random.seed(SEED)
 
     blocks = chain(entangle(892, qubit_support=(0, 1)), RY(0, torch.pi / 2))
-    register = Register(2)
+    register = Register(2, scale=DEFAULT_SPACING)
     circuit = QuantumCircuit(register, blocks)
 
     # first try the standard execution with default configuration

--- a/tests/backends/pulser_basic/test_configuration.py
+++ b/tests/backends/pulser_basic/test_configuration.py
@@ -21,7 +21,7 @@ def test_configuration() -> None:
     np.random.seed(SEED)
 
     blocks = chain(entangle(892, qubit_support=(0, 1)), RY(0, torch.pi / 2))
-    register = Register(2, scale=DEFAULT_SPACING)
+    register = Register(2, spacing=DEFAULT_SPACING)
     circuit = QuantumCircuit(register, blocks)
 
     # first try the standard execution with default configuration
@@ -50,7 +50,7 @@ def test_configuration_as_dict() -> None:
     np.random.seed(SEED)
 
     blocks = chain(entangle(892, qubit_support=(0, 1)), RY(0, torch.pi / 2))
-    register = Register(2, scale=DEFAULT_SPACING)
+    register = Register(2, spacing=DEFAULT_SPACING)
     circuit = QuantumCircuit(register, blocks)
 
     # first try the standard execution with default configuration

--- a/tests/backends/pulser_basic/test_differentiation.py
+++ b/tests/backends/pulser_basic/test_differentiation.py
@@ -51,7 +51,7 @@ def test_pulser_gpsr(block_id: int) -> None:
         spacing = 8.0
 
     # define circuits
-    register = Register.line(2, scale=spacing)
+    register = Register.line(2, spacing=spacing)
     circ = QuantumCircuit(register, block(block_id))
 
     # create input values

--- a/tests/backends/pulser_basic/test_differentiation.py
+++ b/tests/backends/pulser_basic/test_differentiation.py
@@ -5,15 +5,16 @@ import pytest
 import torch
 from metrics import PULSER_GPSR_ACCEPTANCE
 
-from qadence import DifferentiableBackend, DiffMode, Parameter, QuantumCircuit, add_interaction
+from qadence import DifferentiableBackend, DiffMode, Parameter, QuantumCircuit
 from qadence.backends.pulser import Backend as PulserBackend
 from qadence.backends.pyqtorch import Backend as PyQBackend
-from qadence.blocks import chain
+from qadence.blocks import AbstractBlock, chain
 from qadence.constructors import total_magnetization
 from qadence.operations import RX, RY, AnalogRot, AnalogRX, wait
+from qadence.register import Register
 
 
-def circuit(circ_id: int) -> QuantumCircuit:
+def block(circ_id: int) -> AbstractBlock:
     """Helper function to make an example circuit."""
 
     x = Parameter("x", trainable=False)
@@ -32,28 +33,26 @@ def circuit(circ_id: int) -> QuantumCircuit:
             AnalogRX(np.pi / 2),
         )
 
-    circ = QuantumCircuit(2, block)
-
-    return circ
+    return block
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "circ_id",
+    "block_id",
     [1, 2, 3, 4],
 )
-def test_pulser_gpsr(circ_id: int) -> None:
+def test_pulser_gpsr(block_id: int) -> None:
     torch.manual_seed(42)
     np.random.seed(42)
 
-    if circ_id == 1:
+    if block_id == 1:
         spacing = 30.0
     else:
         spacing = 8.0
 
     # define circuits
-    circ = circuit(circ_id)
-    circ_pyq = add_interaction(circ, spacing=spacing)
+    register = Register.line(2, scale=spacing)
+    circ = QuantumCircuit(register, block(block_id))
 
     # create input values
     xs = torch.linspace(1, 2 * np.pi, 30, requires_grad=True)
@@ -63,7 +62,7 @@ def test_pulser_gpsr(circ_id: int) -> None:
 
     # run with pyq backend
     pyq_backend = PyQBackend()
-    conv = pyq_backend.convert(circ_pyq, obs)
+    conv = pyq_backend.convert(circ, obs)
     pyq_circ, pyq_obs, embedding_fn, params = conv
     diff_backend = DifferentiableBackend(pyq_backend, diff_mode=DiffMode.AD)
     expval_pyq = diff_backend.expectation(pyq_circ, pyq_obs, embedding_fn(params, values))
@@ -72,7 +71,7 @@ def test_pulser_gpsr(circ_id: int) -> None:
     )[0]
 
     # run with pulser backend
-    pulser_backend = PulserBackend(config={"spacing": spacing})  # type: ignore[arg-type]
+    pulser_backend = PulserBackend()  # type: ignore[arg-type]
     conv = pulser_backend.convert(circ, obs)
     pulser_circ, pulser_obs, embedding_fn, params = conv
     diff_backend = DifferentiableBackend(pulser_backend, diff_mode=DiffMode.GPSR, shift_prefac=0.2)

--- a/tests/backends/pulser_basic/test_entanglement.py
+++ b/tests/backends/pulser_basic/test_entanglement.py
@@ -21,7 +21,7 @@ DEFAULT_SPACING = 8.0
 def test_entanglement(device_type: Device) -> None:
     block = chain(entangle(1000, qubit_support=(0, 1)), RY(0, 3 * torch.pi / 2))
 
-    register = Register.line(2, scale=DEFAULT_SPACING)
+    register = Register.line(2, spacing=DEFAULT_SPACING)
 
     config = {"device_type": device_type}
 

--- a/tests/backends/pulser_basic/test_entanglement.py
+++ b/tests/backends/pulser_basic/test_entanglement.py
@@ -2,31 +2,31 @@ from __future__ import annotations
 
 from collections import Counter
 
-import pytest
 import torch
 from metrics import JS_ACCEPTANCE
 
 from qadence import sample
 from qadence.backend import BackendName
-from qadence.backends.pulser import Device
-from qadence.blocks import AbstractBlock, chain
+from qadence.backends.pulser.devices import Device, RealisticDevice
+from qadence.blocks import chain
 from qadence.divergences import js_divergence
 from qadence.operations import RY, entangle
 from qadence.register import Register
 
 
-@pytest.mark.parametrize(
-    "blocks,register,goal",
-    [
-        # Bell state
-        (
-            chain(entangle(1000, qubit_support=(0, 1)), RY(0, 3 * torch.pi / 2)),
-            Register(2),
-            Counter({"00": 250, "11": 250}),
-        ),
-    ],
-)
-def test_entanglement(blocks: AbstractBlock, register: Register, goal: Counter) -> None:
+def test_entanglement() -> None:
+    block = chain(entangle(1000, qubit_support=(0, 1)), RY(0, 3 * torch.pi / 2))
+
+    max_amp = RealisticDevice.channels["rydberg_global"].max_amp
+    weak_coupling_const = 1.2
+    spacing = weak_coupling_const * RealisticDevice.rydberg_blockade_radius(max_amp)
+
+    register = Register(2, scale=spacing)
+
     config = {"device_type": Device.REALISTIC}
-    res = sample(register, blocks, backend=BackendName.PULSER, n_shots=500, configuration=config)[0]
+
+    res = sample(register, block, backend=BackendName.PULSER, n_shots=500, configuration=config)[0]
+
+    goal = Counter({"00": 250, "11": 250})
+
     assert js_divergence(res, goal) < JS_ACCEPTANCE

--- a/tests/backends/pulser_basic/test_entanglement.py
+++ b/tests/backends/pulser_basic/test_entanglement.py
@@ -2,28 +2,28 @@ from __future__ import annotations
 
 from collections import Counter
 
+import pytest
 import torch
 from metrics import JS_ACCEPTANCE
 
 from qadence import sample
 from qadence.backend import BackendName
-from qadence.backends.pulser.devices import Device, RealisticDevice
+from qadence.backends.pulser.devices import Device
 from qadence.blocks import chain
 from qadence.divergences import js_divergence
 from qadence.operations import RY, entangle
 from qadence.register import Register
 
+DEFAULT_SPACING = 8.0
 
-def test_entanglement() -> None:
+
+@pytest.mark.parametrize("device_type", [Device.IDEALIZED, Device.REALISTIC])
+def test_entanglement(device_type: Device) -> None:
     block = chain(entangle(1000, qubit_support=(0, 1)), RY(0, 3 * torch.pi / 2))
 
-    max_amp = RealisticDevice.channels["rydberg_global"].max_amp
-    weak_coupling_const = 1.2
-    spacing = weak_coupling_const * RealisticDevice.rydberg_blockade_radius(max_amp)
+    register = Register.line(2, scale=DEFAULT_SPACING)
 
-    register = Register(2, scale=spacing)
-
-    config = {"device_type": Device.REALISTIC}
+    config = {"device_type": device_type}
 
     res = sample(register, block, backend=BackendName.PULSER, n_shots=500, configuration=config)[0]
 

--- a/tests/backends/pulser_basic/test_pulser_conversion.py
+++ b/tests/backends/pulser_basic/test_pulser_conversion.py
@@ -32,7 +32,7 @@ from qadence.register import Register as QadenceRegister
 def test_single_qubit_block_conversion(Qadence_op: AbstractBlock, func: Callable) -> None:
     spacing = 10
     n_qubits = 2
-    reg = QadenceRegister(n_qubits, scale=spacing)
+    reg = QadenceRegister(n_qubits, spacing=spacing)
     circ = QuantumCircuit(reg, Qadence_op)
     config = Configuration(device_type=Device.REALISTIC)
 
@@ -61,7 +61,7 @@ def test_single_qubit_block_conversion(Qadence_op: AbstractBlock, func: Callable
 )
 def test_multiple_qubit_block_conversion(Qadence_op: AbstractBlock, func: Callable) -> None:
     spacing = 10
-    reg = QadenceRegister(2, scale=spacing)
+    reg = QadenceRegister(2, spacing=spacing)
     circ = QuantumCircuit(reg, Qadence_op)
 
     seq1 = make_sequence(circ, Configuration())

--- a/tests/backends/pulser_basic/test_pulser_conversion.py
+++ b/tests/backends/pulser_basic/test_pulser_conversion.py
@@ -32,9 +32,9 @@ from qadence.register import Register as QadenceRegister
 def test_single_qubit_block_conversion(Qadence_op: AbstractBlock, func: Callable) -> None:
     spacing = 10
     n_qubits = 2
-    reg = QadenceRegister(n_qubits)
+    reg = QadenceRegister(n_qubits, scale=spacing)
     circ = QuantumCircuit(reg, Qadence_op)
-    config = Configuration(spacing=spacing, device_type=Device.REALISTIC)
+    config = Configuration(device_type=Device.REALISTIC)
 
     seq1 = make_sequence(circ, config)
     sim1 = QutipEmulator.from_sequence(seq1)
@@ -61,11 +61,10 @@ def test_single_qubit_block_conversion(Qadence_op: AbstractBlock, func: Callable
 )
 def test_multiple_qubit_block_conversion(Qadence_op: AbstractBlock, func: Callable) -> None:
     spacing = 10
-    reg = QadenceRegister(2)
+    reg = QadenceRegister(2, scale=spacing)
     circ = QuantumCircuit(reg, Qadence_op)
-    config = Configuration(spacing=spacing)
 
-    seq1 = make_sequence(circ, config)
+    seq1 = make_sequence(circ, Configuration())
     sim1 = QutipEmulator.from_sequence(seq1)
     res1 = sim1.run()
     sample1 = res1.sample_final_state(500)
@@ -85,5 +84,5 @@ def test_interaction() -> None:
     with pytest.raises(ValueError, match="Pulser does not support other interactions than 'NN'"):
         reg = QadenceRegister(2)
         circ = QuantumCircuit(reg, entangle(100))
-        config = Configuration(spacing=10, interaction=Interaction.XY)
+        config = Configuration(interaction=Interaction.XY)
         make_sequence(circ, config)

--- a/tests/qadence/test_register.py
+++ b/tests/qadence/test_register.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 import os
+from math import isclose
 
 import networkx as nx
 import numpy as np
+from metrics import ATOL_64
 from pytest import approx
 
 from qadence.register import Register
@@ -29,21 +31,21 @@ def test_register() -> None:
     graph.add_edge(0, 1)
     reg = Register(graph)
     assert reg.n_qubits == 2
-    assert reg.min_distance == 0.0
+    assert isclose(reg.min_distance, 0.0, rel_tol=ATOL_64)
 
     # test linear lattice node number
     spacing = 2.0
     r = Register.line(4, spacing=spacing)
     assert len(r.graph) == 4
     assert r == Register.lattice("line", 4, spacing=spacing)
-    assert sum(r.edge_distances.values()) == 3 * spacing
+    assert isclose(sum(r.edge_distances.values()), 3 * spacing, rel_tol=ATOL_64)
     assert len(r.distances) == len(r.all_edges)
 
     # test circular lattice node number
     r = Register.circle(8)
     assert len(r.graph) == 8
     assert r == Register.lattice("circle", 8)
-    assert r.min_distance == 1.0
+    assert isclose(r.min_distance, 1.0, rel_tol=ATOL_64)
 
     # test shape of circular lattice
     distances = calc_dist(r.graph)
@@ -87,11 +89,11 @@ def test_register() -> None:
     # test arbitrary lattice node number
     r = Register.from_coordinates([(0, 1), (0, 2), (0, 3), (1, 3)])
     assert len(r.graph) == 4
-    assert r.min_distance == 1.0
+    assert isclose(r.min_distance, 1.0, rel_tol=ATOL_64)
 
     # test rescale coordinates
     r = r.rescale_coords(scaling=2.0)
-    assert r.min_distance == 2.0
+    assert isclose(r.min_distance, 2.0, rel_tol=ATOL_64)
 
 
 def test_register_to_dict(BasicRegister: Register) -> None:

--- a/tests/qadence/test_register.py
+++ b/tests/qadence/test_register.py
@@ -20,24 +20,30 @@ def calc_dist(graph: nx.Graph) -> np.ndarray:
 
 def test_register() -> None:
     # create register with number of qubits only
-    reg = Register(4)
+    reg = Register(4, spacing=4.0)
     assert reg.n_qubits == 4
+    assert reg.min_distance == 4.0
 
     # create register from arbitrary graph
     graph = nx.Graph()
     graph.add_edge(0, 1)
     reg = Register(graph)
     assert reg.n_qubits == 2
+    assert reg.min_distance == 0.0
 
     # test linear lattice node number
-    r = Register.line(4)
+    spacing = 2.0
+    r = Register.line(4, spacing=spacing)
     assert len(r.graph) == 4
-    assert r == Register.lattice("line", 4)
+    assert r == Register.lattice("line", 4, spacing=spacing)
+    assert sum(r.edge_distances.values()) == 3 * spacing
+    assert len(r.distances) == len(r.all_edges)
 
     # test circular lattice node number
     r = Register.circle(8)
     assert len(r.graph) == 8
     assert r == Register.lattice("circle", 8)
+    assert r.min_distance == 1.0
 
     # test shape of circular lattice
     distances = calc_dist(r.graph)
@@ -81,6 +87,11 @@ def test_register() -> None:
     # test arbitrary lattice node number
     r = Register.from_coordinates([(0, 1), (0, 2), (0, 3), (1, 3)])
     assert len(r.graph) == 4
+    assert r.min_distance == 1.0
+
+    # test rescale coordinates
+    r = r.rescale_coords(scaling=2.0)
+    assert r.min_distance == 2.0
 
 
 def test_register_to_dict(BasicRegister: Register) -> None:


### PR DESCRIPTION
- Moves the register `spacing` as an argument to the `Register` itself.
- Changes the `spacing` functionality: Instead of multiplying whatever coordinates are in the register with the value of the spacing, it rescales the coordinates so that the distance between the two closest qubits is equal to the spacing (consistent with the spacing argument in the Pulser register).
- Rescaling coordinates from the register can still be done with the method `reg.rescale_coords(scaling: float)` which initializes a new register where all coordinates are multiplied by the scaling value.

BREAKING:
- Some of the arguments from the `Register` methods have been changed so that they are all now `spacing`.
- The default scaling of coordinates in the Pulser backend has been removed so that now a Qadence register passed to either the PyQ backend or Pulser backend gives the same results without needing to tune any other config.
- The `spacing` is no longer a valid argument in the Pulser backend configuration.