### PR TITLE
[Bugfix] Consistent variable ordering in QNNs

### DIFF
--- a/qadence/constructors/hamiltonians.py
+++ b/qadence/constructors/hamiltonians.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import List, Tuple, Type, Union
 
 import numpy as np
@@ -236,23 +235,11 @@ def _update_interaction_strength(
     return register
 
 
-# FIXME: Previous hamiltonian / observable functions, now refactored, to be deprecated:
-
-DEPRECATION_MESSAGE = "This function will be removed in the future. "
-
-
 def single_z(qubit: int = 0, z_coefficient: float = 1.0) -> AbstractBlock:
-    message = DEPRECATION_MESSAGE + "Please use `z_coefficient * Z(qubit)` directly."
-    warnings.warn(message, FutureWarning)
     return Z(qubit) * z_coefficient
 
 
 def total_magnetization(n_qubits: int, z_terms: np.ndarray | list | None = None) -> AbstractBlock:
-    message = (
-        DEPRECATION_MESSAGE
-        + "Please use `hamiltonian_factory(n_qubits, detuning=Z, node_coeff=z_terms)`."
-    )
-    warnings.warn(message, FutureWarning)
     return hamiltonian_factory(n_qubits, detuning=Z, detuning_strength=z_terms)
 
 
@@ -261,20 +248,11 @@ def zz_hamiltonian(
     z_terms: np.ndarray | None = None,
     zz_terms: np.ndarray | None = None,
 ) -> AbstractBlock:
-    message = (
-        DEPRECATION_MESSAGE
-        + """
-Please use `hamiltonian_factory(n_qubits, Interaction.ZZ, Z, interaction_strength, z_terms)`. \
-Note that the argument `zz_terms` in this function is a 2D array of size `(n_qubits, n_qubits)`, \
-while `interaction_strength` is expected as a 1D array of size `0.5 * n_qubits * (n_qubits - 1)`."""
-    )
-    warnings.warn(message, FutureWarning)
     if zz_terms is not None:
         register = Register(n_qubits)
         interaction_strength = [zz_terms[edge[0], edge[1]] for edge in register.edges]
     else:
         interaction_strength = None
-
     return hamiltonian_factory(n_qubits, Interaction.ZZ, Z, interaction_strength, z_terms)
 
 
@@ -284,13 +262,6 @@ def ising_hamiltonian(
     z_terms: np.ndarray | None = None,
     zz_terms: np.ndarray | None = None,
 ) -> AbstractBlock:
-    message = (
-        DEPRECATION_MESSAGE
-        + """
-You can build a general transverse field ising model with the `hamiltonian_factory` function. \
-Check the hamiltonian construction tutorial in the documentation for more information."""
-    )
-    warnings.warn(message, FutureWarning)
     zz_ham = zz_hamiltonian(n_qubits, z_terms=z_terms, zz_terms=zz_terms)
     x_ham = hamiltonian_factory(n_qubits, detuning=X, detuning_strength=x_terms)
     return zz_ham + x_ham

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,6 +202,7 @@ def BasicAdjointQNN(BasicFMQuantumCircuit: QuantumCircuit, BasicObservable: Abst
     return QNN(
         BasicFMQuantumCircuit,
         total_magnetization(FM_NQUBITS),
+        inputs=("phi",),
         backend=BackendName.PYQTORCH,
         diff_mode=DiffMode.ADJOINT,
     )

--- a/tests/models/test_qnn.py
+++ b/tests/models/test_qnn.py
@@ -74,7 +74,7 @@ def test_input_nd(dim: int) -> None:
     observable = total_magnetization(n_qubits_per_feature * dim)
     circuit = build_circuit(n_qubits_per_feature, dim)
     a = torch.rand(batch_size, dim)
-    qnn = QNN(circuit, observable)
+    qnn = QNN(circuit, observable, inputs=tuple(f"x{i}" for i in range(dim)))
     assert qnn.in_features == dim
 
     res: torch.Tensor = qnn(a)


### PR DESCRIPTION
Before this MR we relied on the order of `self.inputs` defined in the `QuantumModel`
```
self.inputs = [p for p in circuit.unique_parameters if not p.trainable and not p.is_number]
```
when casting QNN input tensors to dicts.