### PR TITLE
[Feature] Allow turning off the semi-local addressing pattern in pyqtorch backend

### DIFF
--- a/docs/digital_analog_qc/semi-local-addressing.md
+++ b/docs/digital_analog_qc/semi-local-addressing.md
@@ -115,6 +115,13 @@ expval_pulser = model_pulser.expectation(values = value)
 print(f"Expectation value on Pulser: \n{expval_pulser.flatten().detach()}\n")  # markdown-exec: hide
 ```
 
+Note that by default the addressing pattern terms are added to every analog operation in the circuit. However, it is
+possible to turn the addressing pattern off for specific operations by passing `add_pattern=False` in the operation.
+For example `AnalogRX(pi)` will get the extra addressing pattern term, but `AnalogRX(pi, add_pattern=False)` will not.
+This is currently only implemented for the PyQTorch backend. If an addressing pattern is specified for the Pulser backend,
+it will be added to all the blocks.
+
+
 ### Trainable weights
 
 !!! note

--- a/qadence/analog/parse_analog.py
+++ b/qadence/analog/parse_analog.py
@@ -52,13 +52,11 @@ def add_background_hamiltonian(
         # Create addressing pattern:
         h_addr = rydberg_pattern_hamiltonian(input_register)
 
-        h_background = h_int + h_addr if h_addr is not None else h_int
-
         output_block = apply_fn_to_blocks(
             input_block,
             _analog_to_hevo,
             input_register,
-            h_background,
+            (h_int, h_addr),
         )
     else:
         output_block = input_block
@@ -69,8 +67,25 @@ def add_background_hamiltonian(
         return output_block
 
 
+def _build_ham_evo(
+    block: WaitBlock | ConstantAnalogRotation,
+    h_int: AbstractBlock,
+    h_drive: AbstractBlock | None,
+    h_addr: AbstractBlock | None,
+) -> HamEvo:
+    duration = block.parameters.duration
+    h_block = h_int
+    if h_drive is not None:
+        h_block += h_drive
+    if block.add_pattern and h_addr is not None:
+        h_block += h_addr
+    return HamEvo(h_block, duration / 1000)
+
+
 def _analog_to_hevo(
-    block: AbstractBlock, register: Register, h_background: AbstractBlock
+    block: AbstractBlock,
+    register: Register,
+    h_terms: tuple[AbstractBlock, AbstractBlock | None],
 ) -> AbstractBlock:
     """
     Converter from AnalogBlock to the respective HamEvo.
@@ -78,14 +93,14 @@ def _analog_to_hevo(
     Any other block not covered by the specific conditions below is left unchanged.
     """
 
+    h_int, h_addr = h_terms
+
     if isinstance(block, WaitBlock):
-        duration = block.parameters.duration
-        return HamEvo(h_background, duration / 1000)
+        return _build_ham_evo(block, h_int, None, h_addr)
 
     if isinstance(block, ConstantAnalogRotation):
         h_drive = rydberg_drive_hamiltonian(block, register)
-        duration = block.parameters.duration
-        return HamEvo(h_drive + h_background, duration / 1000)
+        return _build_ham_evo(block, h_int, h_drive, h_addr)
 
     if isinstance(block, AnalogKron):
         # Needed to ensure kronned Analog blocks are implemented
@@ -96,12 +111,10 @@ def _analog_to_hevo(
         ops = []
         for block in block.blocks:
             if isinstance(block, ConstantAnalogRotation):
-                duration = block.parameters.duration
                 h_drive = rydberg_drive_hamiltonian(block, register)
-                ops.append(HamEvo(h_drive + h_background, duration / 1000))
+                ops.append(_build_ham_evo(block, h_int, h_drive, h_addr))
         if len(ops) == 0:
-            duration = block.parameters.duration  # type: ignore
-            ops.append(HamEvo(h_background, duration / 1000))
+            ops.append(_build_ham_evo(block, h_int, None, h_addr))  # type: ignore [arg-type]
         return chain(*ops)
 
     return block

--- a/qadence/backends/pulser/pulses.py
+++ b/qadence/backends/pulser/pulses.py
@@ -20,12 +20,15 @@ from qadence.blocks.analog import (
     Interaction,
     WaitBlock,
 )
+from qadence.logger import get_logger
 from qadence.operations import RX, RY, RZ, AnalogEntanglement, OpName
 from qadence.parameters import evaluate
 
 from .channels import GLOBAL_CHANNEL, LOCAL_CHANNEL
 from .config import Configuration
 from .waveforms import SquareWaveform
+
+logger = get_logger(__file__)
 
 TVar = Union[Variable, VariableItem]
 
@@ -118,6 +121,11 @@ def add_pulses(
 
     # TODO: lets move those to `@singledipatch`ed functions
     if isinstance(block, WaitBlock):
+        if not block.add_pattern:
+            logger.warning(
+                "Found block with `add_pattern = False`. This is not yet supported in the Pulser "
+                "backend. If an addressing pattern is specified, it will be added to all blocks."
+            )
         # wait if its a global wait
         if block.qubit_support.is_global:
             (uuid, duration) = block.parameters.uuid_param("duration")
@@ -133,6 +141,11 @@ def add_pulses(
                 raise ValueError("Trying to wait on qubits outside of support.")
 
     elif isinstance(block, ConstantAnalogRotation):
+        if not block.add_pattern:
+            logger.warning(
+                "Found block with `add_pattern = False`. This is not yet supported in the Pulser "
+                "backend. If an addressing pattern is specified, it will be added to all blocks."
+            )
         ps = block.parameters
         (a_uuid, alpha) = ps.uuid_param("alpha")
         (w_uuid, omega) = ps.uuid_param("omega")

--- a/qadence/blocks/analog.py
+++ b/qadence/blocks/analog.py
@@ -123,6 +123,8 @@ class WaitBlock(AnalogBlock):
     parameters: ParamMap = ParamMap(duration=1000.0)  # ns
     qubit_support: QubitSupport = QubitSupport("global")
 
+    add_pattern: bool = False
+
     @property
     def eigenvalues_generator(self) -> torch.Tensor | None:
         return self._eigenvalues_generator
@@ -165,6 +167,8 @@ class ConstantAnalogRotation(AnalogBlock):
         phase=0.0,  # rad
     )
     qubit_support: QubitSupport = QubitSupport("global")
+
+    add_pattern: bool = False
 
     @property
     def _block_title(self) -> str:

--- a/qadence/blocks/analog.py
+++ b/qadence/blocks/analog.py
@@ -123,7 +123,7 @@ class WaitBlock(AnalogBlock):
     parameters: ParamMap = ParamMap(duration=1000.0)  # ns
     qubit_support: QubitSupport = QubitSupport("global")
 
-    add_pattern: bool = False
+    add_pattern: bool = True
 
     @property
     def eigenvalues_generator(self) -> torch.Tensor | None:
@@ -168,7 +168,7 @@ class ConstantAnalogRotation(AnalogBlock):
     )
     qubit_support: QubitSupport = QubitSupport("global")
 
-    add_pattern: bool = False
+    add_pattern: bool = True
 
     @property
     def _block_title(self) -> str:

--- a/qadence/operations.py
+++ b/qadence/operations.py
@@ -1107,6 +1107,7 @@ def _cast(T: Any, val: Any) -> Any:
 def wait(
     duration: TNumber | sympy.Basic,
     qubit_support: str | QubitSupport | tuple = "global",
+    add_pattern: bool = True,
 ) -> WaitBlock:
     """Constructs a [`WaitBlock`][qadence.blocks.analog.WaitBlock].
 
@@ -1120,7 +1121,7 @@ def wait(
     """
     q = _cast(QubitSupport, qubit_support)
     ps = ParamMap(duration=duration)
-    return WaitBlock(parameters=ps, qubit_support=q)
+    return WaitBlock(parameters=ps, qubit_support=q, add_pattern=add_pattern)
 
 
 def entangle(
@@ -1138,6 +1139,7 @@ def AnalogRot(
     delta: float | str | Parameter = 0,
     phase: float | str | Parameter = 0,
     qubit_support: str | QubitSupport | Tuple = "global",
+    add_pattern: bool = True,
 ) -> ConstantAnalogRotation:
     """General analog rotation operation.
 
@@ -1154,16 +1156,23 @@ def AnalogRot(
     q = _cast(QubitSupport, qubit_support)
     if isinstance(duration, str):
         duration = Parameter(duration)
-    alpha = duration * sympy.sqrt(omega**2 + delta**2) / 1000  # type: ignore [operator]
+    if isinstance(omega, str):
+        omega = Parameter(omega)
+    if isinstance(delta, str):
+        delta = Parameter(delta)
+    if isinstance(phase, str):
+        phase = Parameter(phase)
+    alpha = duration * sympy.sqrt(omega**2 + delta**2) / 1000
 
     ps = ParamMap(alpha=alpha, duration=duration, omega=omega, delta=delta, phase=phase)
-    return ConstantAnalogRotation(parameters=ps, qubit_support=q)
+    return ConstantAnalogRotation(parameters=ps, qubit_support=q, add_pattern=add_pattern)
 
 
 def _analog_rot(
     angle: float | str | Parameter,
     qubit_support: str | QubitSupport | Tuple,
     phase: float,
+    add_pattern: bool = True,
 ) -> ConstantAnalogRotation:
     q = _cast(QubitSupport, qubit_support)
     # assuming some arbitrary omega = π rad/μs
@@ -1178,12 +1187,13 @@ def _analog_rot(
     # and compute omega like this:
     # omega = alpha / duration * 1000
     ps = ParamMap(alpha=alpha, duration=duration, omega=omega, delta=0, phase=phase)
-    return ConstantAnalogRotation(parameters=ps, qubit_support=q)
+    return ConstantAnalogRotation(parameters=ps, qubit_support=q, add_pattern=add_pattern)
 
 
 def AnalogRX(
     angle: float | str | Parameter,
     qubit_support: str | QubitSupport | Tuple = "global",
+    add_pattern: bool = True,
 ) -> ConstantAnalogRotation:
     """Analog X rotation.
 
@@ -1201,12 +1211,13 @@ def AnalogRX(
     Returns:
         ConstantAnalogRotation
     """
-    return _analog_rot(angle, qubit_support, phase=0)
+    return _analog_rot(angle, qubit_support, phase=0, add_pattern=add_pattern)
 
 
 def AnalogRY(
     angle: float | str | Parameter,
     qubit_support: str | QubitSupport | Tuple = "global",
+    add_pattern: bool = True,
 ) -> ConstantAnalogRotation:
     """Analog Y rotation.
 
@@ -1223,12 +1234,13 @@ def AnalogRY(
     Returns:
         ConstantAnalogRotation
     """
-    return _analog_rot(angle, qubit_support, phase=-np.pi / 2)
+    return _analog_rot(angle, qubit_support, phase=-np.pi / 2, add_pattern=add_pattern)
 
 
 def AnalogRZ(
     angle: float | str | Parameter,
     qubit_support: str | QubitSupport | Tuple = "global",
+    add_pattern: bool = True,
 ) -> ConstantAnalogRotation:
     """Analog Z rotation. Shorthand for [`AnalogRot`][qadence.operations.AnalogRot]:
     ```
@@ -1241,7 +1253,7 @@ def AnalogRZ(
     delta = np.pi
     duration = alpha / delta * 1000
     ps = ParamMap(alpha=alpha, duration=duration, omega=0, delta=delta, phase=0.0)
-    return ConstantAnalogRotation(qubit_support=q, parameters=ps)
+    return ConstantAnalogRotation(qubit_support=q, parameters=ps, add_pattern=add_pattern)
 
 
 # gate sets


### PR DESCRIPTION
Adds the possibility to turn off the addressing pattern for specific analog operations in the pyqtorch backend.

Currently just throws a warning in the pulser backend. The implementation there is a bit more tricky.