### PR TITLE
[Refact] Replace alias wait with AnalogInteraction

### DIFF
--- a/docs/digital_analog_qc/analog-basics.md
+++ b/docs/digital_analog_qc/analog-basics.md
@@ -268,16 +268,16 @@ print("States equivalent: ", bool_equiv)
 
 Finally, besides applying specific qubit rotations, we can also choose to evolve only the interaction term
 $\mathcal{H}^\text{int}$, equivalent to setting $\Omega = \delta = \phi = 0$. To do so, Qadence provides the
-function `wait` which does exactly this.
+function `AnalogInteraction` which does exactly this.
 
 ```python exec="on" source="material-block" result="json" session="int"
-from qadence import Register, BackendName, random_state, equivalent_state, wait, run
+from qadence import Register, BackendName, random_state, equivalent_state, AnalogInteraction, run
 
 n_qubits = 3
 reg = Register.line(n_qubits, spacing=8.0)
 
 duration = 1000.
-op = wait(duration = duration)
+op = AnalogInteraction(duration = duration)
 
 init_state = random_state(n_qubits)
 
@@ -376,7 +376,7 @@ of the emulated analog interface, and in the next tutorial on Quantum Circuit Le
 in a simple QML example. Here we specify some extra details of this interface.
 
 In the block system, all the Analog rotation operators initialize a [`ConstantAnalogRotation`][qadence.blocks.analog.ConstantAnalogRotation]
-block, while the `wait` operation initializes a [`WaitBlock`][qadence.blocks.analog.WaitBlock]. As we have shown, by default,
+block, while the `AnalogInteraction` operation initializes a [`WaitBlock`][qadence.blocks.analog.WaitBlock]. As we have shown, by default,
 these blocks use a global qubit support, which can be passed explicitly by setting `qubit_support = "global"`. However, the blocks do support
 local qubit supports, with some constraints. The main constraint is that using `kron` on operators with different durations is not allowed.
 

--- a/docs/digital_analog_qc/analog-basics.md
+++ b/docs/digital_analog_qc/analog-basics.md
@@ -371,10 +371,10 @@ In the previous section we have exemplified the main ingredients of the current 
 of the emulated analog interface, and in the next tutorial on Quantum Circuit Learning we will exmplify its usage
 in a simple QML example. Here we specify some extra details of this interface.
 
-In the block system, all the Analog rotation operators initialize a [`ConstantAnalogRotation`][qadence.blocks.analog.ConstantAnalogRotation]
-block, while the `AnalogInteraction` operation initializes a [`InteractionBlock`][qadence.blocks.analog.InteractionBlock]. As we have shown, by default,
-these blocks use a global qubit support, which can be passed explicitly by setting `qubit_support = "global"`. However, the blocks do support
-local qubit supports, with some constraints. The main constraint is that using `kron` on operators with different durations is not allowed.
+In the block system, all analog rotation operators initialize a [`ConstantAnalogRotation`][qadence.blocks.analog.ConstantAnalogRotation]
+block, while the `AnalogInteraction` operation initializes an [`InteractionBlock`][qadence.blocks.analog.InteractionBlock]. As we have shown, by default,
+these blocks use a global qubit support, which can be passed explicitly by setting `qubit_support = QubitSupportType.GLOBAL`. However, composing blocks using `kron`
+with local qubit supports and different durations is not allowed.
 
 ```python exec="on" source="material-block" result="json" session="details"
 from qadence import AnalogRX, AnalogRY, Register, kron

--- a/docs/digital_analog_qc/analog-basics.md
+++ b/docs/digital_analog_qc/analog-basics.md
@@ -372,7 +372,7 @@ of the emulated analog interface, and in the next tutorial on Quantum Circuit Le
 in a simple QML example. Here we specify some extra details of this interface.
 
 In the block system, all the Analog rotation operators initialize a [`ConstantAnalogRotation`][qadence.blocks.analog.ConstantAnalogRotation]
-block, while the `AnalogInteraction` operation initializes a [`WaitBlock`][qadence.blocks.analog.WaitBlock]. As we have shown, by default,
+block, while the `AnalogInteraction` operation initializes a [`InteractionBlock`][qadence.blocks.analog.InteractionBlock]. As we have shown, by default,
 these blocks use a global qubit support, which can be passed explicitly by setting `qubit_support = "global"`. However, the blocks do support
 local qubit supports, with some constraints. The main constraint is that using `kron` on operators with different durations is not allowed.
 

--- a/docs/digital_analog_qc/analog-qcl.md
+++ b/docs/digital_analog_qc/analog-qcl.md
@@ -6,7 +6,7 @@ $8~\mu\text{m}$ as done in the [basic tutorial](analog-basics.md).
 
 ```python exec="on" source="material-block" session="qcl"
 from qadence import Register, FeatureParameter, chain
-from qadence import AnalogRX, AnalogRY, AnalogRZ, wait
+from qadence import AnalogRX, AnalogRY, AnalogRZ, AnalogInteraction
 from sympy import acos
 
 # Line register
@@ -40,15 +40,15 @@ ansatz = chain(
     AnalogRX("tht_0"),
     AnalogRY("tht_1"),
     AnalogRZ("tht_2"),
-    wait(t_0),
+    AnalogInteraction(t_0),
     AnalogRX("tht_3"),
     AnalogRY("tht_4"),
     AnalogRZ("tht_5"),
-    wait(t_1),
+    AnalogInteraction(t_1),
     AnalogRX("tht_6"),
     AnalogRY("tht_7"),
     AnalogRZ("tht_8"),
-    wait(t_2),
+    AnalogInteraction(t_2),
 )
 ```
 

--- a/docs/digital_analog_qc/pulser-basic.md
+++ b/docs/digital_analog_qc/pulser-basic.md
@@ -169,7 +169,7 @@ A major advantage of the block-based interface in Qadence is the ease to compose
 operations from a restricted set of primitive ones. In the following, a custom entanglement operation is used as an example.
 
 The operation consists of moving _all_ the qubits to the $X$-basis. This is realized when the atomic interaction performs a
-controlled-$Z$ operation during the free evolution. As seen before, this is implemented with the `AnalogInteraction` and `AnalogRY` blocks and
+controlled-$Z$ operation during the free evolution. As seen before, this is implemented with the `AnalogInteraction` and `AnalogRY` blocks together with
 appropriate parameters.
 
 ```python exec="on" source="material-block" session="pulser-basic"

--- a/docs/digital_analog_qc/pulser-basic.md
+++ b/docs/digital_analog_qc/pulser-basic.md
@@ -53,10 +53,10 @@ Currently, the Pulser backend supports the following operations:
 
 | gate        | description                                                                                      | trainable parameter |
 |-------------|--------------------------------------------------------------------------------------------------|---------------------|
-| `RX`, `RY`     | Single qubit rotations. Notice that the interaction is on and this affects the resulting gate fidelity.                                                                        | rotation angle      |
-| `AnalogRX`, `AnalogRY`, `AnalogRZ` | Span a single qubit rotation among the entire register.                                          | rotation angle      |
+| `RX`, `RY`     | Single qubit rotations. Notice that the interaction is on and this affects the resulting gate fidelity.          | rotation angle      |
+| `AnalogRX`, `AnalogRY`, `AnalogRZ` | Span a single qubit rotation among the entire register.                                      | rotation angle      |
 | `entangle`  | Fully entangle the register.                                                                     | interaction time    |
-| `wait`      | An idle block to wait for the system to free-evolve for a duration according to the interaction. | free evolution time |
+| `AnalogInteraction`      | An idle block to wait for the system to free-evolve for a duration according to the interaction. | free evolution time |
 
 ## Sequence the Bell state on a two qubit register
 
@@ -169,17 +169,17 @@ A major advantage of the block-based interface in Qadence is the ease to compose
 operations from a restricted set of primitive ones. In the following, a custom entanglement operation is used as an example.
 
 The operation consists of moving _all_ the qubits to the $X$-basis. This is realized when the atomic interaction performs a
-controlled-$Z$ operation during the free evolution. As seen before, this is implemented with the `wait` and `AnalogRY` blocks and
+controlled-$Z$ operation during the free evolution. As seen before, this is implemented with the `AnalogInteraction` and `AnalogRY` blocks and
 appropriate parameters.
 
 ```python exec="on" source="material-block" session="pulser-basic"
-from qadence import AnalogRY, chain, wait
+from qadence import AnalogRY, chain, AnalogInteraction
 
 # Custom entanglement operation.
 def my_entanglement(duration):
     return chain(
         AnalogRY(-torch.pi / 2),
-        wait(duration)
+        AnalogInteraction(duration)
     )
 
 protocol = chain(

--- a/docs/digital_analog_qc/pulser-basic.md
+++ b/docs/digital_analog_qc/pulser-basic.md
@@ -56,7 +56,7 @@ Currently, the Pulser backend supports the following operations:
 | `RX`, `RY`     | Single qubit rotations. Notice that the interaction is on and this affects the resulting gate fidelity.          | rotation angle      |
 | `AnalogRX`, `AnalogRY`, `AnalogRZ` | Span a single qubit rotation among the entire register.                                      | rotation angle      |
 | `entangle`  | Fully entangle the register.                                                                     | interaction time    |
-| `AnalogInteraction`      | An idle block to wait for the system to free-evolve for a duration according to the interaction. | free evolution time |
+| `AnalogInteraction`      | An idle block to to free-evolve for a duration according to the interaction. | free evolution time |
 
 ## Sequence the Bell state on a two qubit register
 

--- a/docs/qadence/operations.md
+++ b/docs/qadence/operations.md
@@ -149,7 +149,7 @@ called *gates* elsewhere.
       show_root_heading: true
       show_root_full_path: false
 
-::: qadence.operations.wait
+::: qadence.operations.AnalogInteraction
     options:
       show_root_heading: true
       show_root_full_path: false

--- a/examples/draw.py
+++ b/examples/draw.py
@@ -49,7 +49,7 @@ b = chain(
     HamEvo(kron(*map(Z, range(constants.n_qubits))), 10),
     AnalogRX("x"),
     AnalogRX("x", qubit_support=(3, 4, 5)),
-    wait("x"),
+    AnalogInteraction("x"),
     vari,
     add(*map(X, range(constants.n_qubits))),
     2.1 * kron(*map(X, range(constants.n_qubits))),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 ]
 requires-python = ">=3.9,<3.12"
 license = {text = "Apache 2.0"}
-version = "1.2.2"
+version = "1.2.3"
 classifiers=[
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",

--- a/qadence/analog/parse_analog.py
+++ b/qadence/analog/parse_analog.py
@@ -10,7 +10,7 @@ from qadence.blocks.abstract import AbstractBlock
 from qadence.blocks.analog import (
     AnalogKron,
     ConstantAnalogRotation,
-    WaitBlock,
+    InteractionBlock,
 )
 from qadence.circuit import QuantumCircuit
 from qadence.operations import HamEvo
@@ -92,7 +92,7 @@ def _analog_to_hevo(
     Any other block not covered by the specific conditions below is left unchanged.
     """
 
-    if isinstance(block, WaitBlock):
+    if isinstance(block, InteractionBlock):
         h_background = h_int
         if block.add_pattern and h_addr is not None:
             h_background += h_addr

--- a/qadence/backend.py
+++ b/qadence/backend.py
@@ -18,7 +18,7 @@ from qadence.blocks import (
     TimeEvolutionBlock,
     embedding,
 )
-from qadence.blocks.analog import ConstantAnalogRotation, WaitBlock
+from qadence.blocks.analog import ConstantAnalogRotation, InteractionBlock
 from qadence.circuit import QuantumCircuit
 from qadence.logger import get_logger
 from qadence.measurements import Measurements
@@ -81,7 +81,7 @@ class BackendConfiguration:
         """
         param_ids: Tuple
         # FIXME: better type hiearchy?
-        types = (TimeEvolutionBlock, ParametricBlock, ConstantAnalogRotation, WaitBlock)
+        types = (TimeEvolutionBlock, ParametricBlock, ConstantAnalogRotation, InteractionBlock)
         if not isinstance(blk, types):
             raise TypeError(f"Can not infer param name from {type(blk)}")
         else:

--- a/qadence/backends/pulser/pulses.py
+++ b/qadence/backends/pulser/pulses.py
@@ -42,7 +42,7 @@ supported_gates = [
     OpName.ANALOGRY,
     OpName.ANALOGRZ,
     OpName.ANALOGSWAP,
-    OpName.WAIT,
+    OpName.ANALOGINTERACTION,
 ]
 
 

--- a/qadence/blocks/analog.py
+++ b/qadence/blocks/analog.py
@@ -101,7 +101,7 @@ class AnalogBlock(AbstractBlock):
 @dataclass(eq=False, repr=False)
 class WaitBlock(AnalogBlock):
     """
-    Waits.
+    Evolves the interaction term for a register of qubits.
 
     In real interacting quantum devices, it means letting the system evolve freely according
     to the time-dependent Schrodinger equation. With emulators, this block is translated to an
@@ -115,7 +115,7 @@ class WaitBlock(AnalogBlock):
 
     with `nᵢ = (1-Zᵢ)/2`.
 
-    To construct this block, use the [`wait`][qadence.operations.wait] function.
+    To construct, use the [`AnalogInteraction`][qadence.operations.AnalogInteraction] function.
     """
 
     _eigenvalues_generator: torch.Tensor | None = None
@@ -262,12 +262,12 @@ class AnalogChain(AnalogComposite):
 
         Example:
         ```python exec="on" source="material-block" result="json"
-        from qadence import X, chain, wait
+        from qadence import X, chain, AnalogInteraction
 
-        b = chain(wait(200), wait(200))
+        b = chain(AnalogInteraction(200), AnalogInteraction(200))
         print(type(b))  # this is an `AnalogChain`
 
-        b = chain(X(0), wait(200))
+        b = chain(X(0), AnalogInteraction(200))
         print(type(b))  # this is a general `ChainBlock`
         ```
         """

--- a/qadence/blocks/analog.py
+++ b/qadence/blocks/analog.py
@@ -99,7 +99,7 @@ class AnalogBlock(AbstractBlock):
 
 
 @dataclass(eq=False, repr=False)
-class WaitBlock(AnalogBlock):
+class InteractionBlock(AnalogBlock):
     """
     Evolves the interaction term for a register of qubits.
 
@@ -215,7 +215,7 @@ class AnalogComposite(AnalogBlock):
 
     def __init__(self, blocks: Tuple[AnalogBlock, ...]):
         self.blocks = blocks
-        # FIXME: add additional Wait block if we have parameterized durations
+        # FIXME: add additional InteractionBlock if we have parameterized durations
 
     @property  # type: ignore[misc, override]
     def qubit_support(self) -> QubitSupport:
@@ -254,7 +254,7 @@ class AnalogChain(AnalogComposite):
         stricter validation than the general `ChainBlock`.
 
         `AnalogChain`s can only be constructed from `AnalogKron` blocks or
-        _**globally supported**_, primitive, analog blocks (like `WaitBlock`s and
+        _**globally supported**_, primitive, analog blocks (like `InteractionBlock`s and
         `ConstantAnalogRotation`s).
 
         Automatically constructed by the [`chain`][qadence.blocks.utils.chain]

--- a/qadence/blocks/analog.py
+++ b/qadence/blocks/analog.py
@@ -101,7 +101,7 @@ class AnalogBlock(AbstractBlock):
 @dataclass(eq=False, repr=False)
 class InteractionBlock(AnalogBlock):
     """
-    Evolves the interaction term for a register of qubits.
+    Free-evolution for the interaction term of a register of qubits.
 
     In real interacting quantum devices, it means letting the system evolve freely according
     to the time-dependent Schrodinger equation. With emulators, this block is translated to an

--- a/qadence/blocks/utils.py
+++ b/qadence/blocks/utils.py
@@ -20,7 +20,12 @@ from qadence.blocks import (
     ScaleBlock,
     TimeEvolutionBlock,
 )
-from qadence.blocks.analog import AnalogBlock, AnalogComposite, ConstantAnalogRotation, WaitBlock
+from qadence.blocks.analog import (
+    AnalogBlock,
+    AnalogComposite,
+    ConstantAnalogRotation,
+    InteractionBlock,
+)
 from qadence.blocks.analog import chain as analog_chain
 from qadence.blocks.analog import kron as analog_kron
 from qadence.exceptions import NotPauliBlockError
@@ -218,7 +223,9 @@ def uuid_to_block(block: AbstractBlock, d: dict[str, Expr] = None) -> dict[str, 
         uuid_to_block(block.block, d)
 
     # special analog cases should go away soon
-    elif isinstance(block, (WaitBlock, ConstantAnalogRotation, operations.AnalogEntanglement)):
+    elif isinstance(
+        block, (InteractionBlock, ConstantAnalogRotation, operations.AnalogEntanglement)
+    ):
         for uuid in block.parameters.uuids():
             d[uuid] = block
 

--- a/qadence/draw/utils.py
+++ b/qadence/draw/utils.py
@@ -21,7 +21,7 @@ from qadence.blocks import (
     ScaleBlock,
     chain,
 )
-from qadence.blocks.analog import ConstantAnalogRotation, WaitBlock
+from qadence.blocks.analog import ConstantAnalogRotation, InteractionBlock
 from qadence.circuit import QuantumCircuit
 from qadence.models import QuantumModel
 from qadence.operations import RX, RY, RZ, SWAP, HamEvo, I
@@ -213,8 +213,8 @@ def _(
         start, stop = min(block.qubit_support), block.n_qubits
         _make_cluster(qcd, labels, start, stop, qcd.theme.get_add_cluster_attr())
 
-    elif isinstance(block, WaitBlock):
-        labels = ["Wait", f"t = {_expr_string(block.parameters.duration)}"]
+    elif isinstance(block, InteractionBlock):
+        labels = ["Interaction", f"t = {_expr_string(block.parameters.duration)}"]
         is_global = block.qubit_support.is_global
         start = 0 if is_global else min(block.qubit_support)
         stop = qcd.nb_wires if is_global else block.n_qubits

--- a/qadence/draw/utils.py
+++ b/qadence/draw/utils.py
@@ -214,7 +214,7 @@ def _(
         _make_cluster(qcd, labels, start, stop, qcd.theme.get_add_cluster_attr())
 
     elif isinstance(block, WaitBlock):
-        labels = ["wait", f"t = {_expr_string(block.parameters.duration)}"]
+        labels = ["Wait", f"t = {_expr_string(block.parameters.duration)}"]
         is_global = block.qubit_support.is_global
         start = 0 if is_global else min(block.qubit_support)
         stop = qcd.nb_wires if is_global else block.n_qubits

--- a/qadence/mitigations/analog_zne.py
+++ b/qadence/mitigations/analog_zne.py
@@ -11,7 +11,7 @@ from qadence.backends.api import backend_factory
 from qadence.backends.pulser.backend import Backend
 from qadence.blocks import block_to_tensor
 from qadence.blocks.abstract import AbstractBlock
-from qadence.blocks.analog import ConstantAnalogRotation, WaitBlock
+from qadence.blocks.analog import ConstantAnalogRotation, InteractionBlock
 from qadence.circuit import QuantumCircuit
 from qadence.measurements import Measurements
 from qadence.mitigations import Mitigations
@@ -52,7 +52,7 @@ def pulse_experiment(
     def mutate_params(block: AbstractBlock, stretch: float) -> AbstractBlock:
         """Closure to retrieve and stretch analog parameters."""
         # Check for stretchable analog block.
-        if isinstance(block, (ConstantAnalogRotation, WaitBlock)):
+        if isinstance(block, (ConstantAnalogRotation, InteractionBlock)):
             stretched_duration = block.parameters.duration * stretch
             stretched_omega = block.parameters.omega / stretch
             stretched_delta = block.parameters.delta / stretch

--- a/qadence/operations.py
+++ b/qadence/operations.py
@@ -27,8 +27,8 @@ from qadence.blocks import (
 from qadence.blocks.analog import (
     AnalogBlock,
     ConstantAnalogRotation,
+    InteractionBlock,
     QubitSupport,
-    WaitBlock,
 )
 from qadence.blocks.block_to_tensor import block_to_tensor
 from qadence.blocks.primitive import ProjectorBlock
@@ -1094,34 +1094,34 @@ def AnalogInteraction(
     duration: TNumber | sympy.Basic,
     qubit_support: str | QubitSupport | tuple = "global",
     add_pattern: bool = True,
-) -> WaitBlock:
+) -> InteractionBlock:
     """Evolution of the interaction term for a register of qubits.
 
-    Constructs a [`WaitBlock`][qadence.blocks.analog.WaitBlock].
+    Constructs a [`InteractionBlock`][qadence.blocks.analog.InteractionBlock].
 
     Arguments:
         duration: Time to evolve the interaction for in nanoseconds.
-        qubit_support: Qubits the `WaitBlock` is applied to. Can be either
-            `"global"` to apply the wait block to all qubits or a tuple of integers.
+        qubit_support: Qubits the `InteractionBlock` is applied to. Can be either
+            `"global"` to evolve the interaction block to all qubits or a tuple of integers.
 
     Returns:
-        a `WaitBlock`
+        a `InteractionBlock`
     """
     q = _cast(QubitSupport, qubit_support)
     ps = ParamMap(duration=duration)
-    return WaitBlock(parameters=ps, qubit_support=q, add_pattern=add_pattern)
+    return InteractionBlock(parameters=ps, qubit_support=q, add_pattern=add_pattern)
 
 
 def wait(
     duration: TNumber | sympy.Basic,
     qubit_support: str | QubitSupport | tuple = "global",
     add_pattern: bool = True,
-) -> WaitBlock:
+) -> InteractionBlock:
     logger.warning("The alias `wait` is deprecated, please use `AnalogInteraction`")
     return AnalogInteraction(duration, qubit_support, add_pattern)
 
 
-# FIXME: better name that stresses difference to `Wait`?
+# FIXME: clarify the usage of this gate, rename more formally, and implement in PyQ
 @dataclass(eq=False, repr=False)
 class AnalogEntanglement(AnalogBlock):
     parameters: ParamMap = ParamMap(duration=1.0)

--- a/qadence/operations.py
+++ b/qadence/operations.py
@@ -1103,6 +1103,8 @@ def AnalogInteraction(
         duration: Time to evolve the interaction for in nanoseconds.
         qubit_support: Qubits the `InteractionBlock` is applied to. Can be either
             `"global"` to evolve the interaction block to all qubits or a tuple of integers.
+        add_pattern: False disables the semi-local addressing pattern
+            for the execution of this specific block.
 
     Returns:
         a `InteractionBlock`
@@ -1161,6 +1163,8 @@ def AnalogRot(
         delta: Rotation frequency [rad/μs]
         phase: Phase angle [rad]
         qubit_support: Defines the (local/global) qubit support
+        add_pattern: False disables the semi-local addressing pattern
+            for the execution of this specific block.
 
     Returns:
         ConstantAnalogRotation

--- a/qadence/operations.py
+++ b/qadence/operations.py
@@ -90,6 +90,7 @@ __all__ = [
     "wait",
     "entangle",
     "AnalogEntanglement",
+    "AnalogInteraction",
     "AnalogRot",
     "AnalogRX",
     "AnalogRY",
@@ -1085,6 +1086,41 @@ class Toffoli(ControlBlock):
         )
 
 
+def _cast(T: Any, val: Any) -> Any:
+    return val if isinstance(val, T) else T(val)
+
+
+def AnalogInteraction(
+    duration: TNumber | sympy.Basic,
+    qubit_support: str | QubitSupport | tuple = "global",
+    add_pattern: bool = True,
+) -> WaitBlock:
+    """Evolution of the interaction term for a register of qubits.
+
+    Constructs a [`WaitBlock`][qadence.blocks.analog.WaitBlock].
+
+    Arguments:
+        duration: Time to evolve the interaction for in nanoseconds.
+        qubit_support: Qubits the `WaitBlock` is applied to. Can be either
+            `"global"` to apply the wait block to all qubits or a tuple of integers.
+
+    Returns:
+        a `WaitBlock`
+    """
+    q = _cast(QubitSupport, qubit_support)
+    ps = ParamMap(duration=duration)
+    return WaitBlock(parameters=ps, qubit_support=q, add_pattern=add_pattern)
+
+
+def wait(
+    duration: TNumber | sympy.Basic,
+    qubit_support: str | QubitSupport | tuple = "global",
+    add_pattern: bool = True,
+) -> WaitBlock:
+    logger.warning("The alias `wait` is deprecated, please use `AnalogInteraction`")
+    return AnalogInteraction(duration, qubit_support, add_pattern)
+
+
 # FIXME: better name that stresses difference to `Wait`?
 @dataclass(eq=False, repr=False)
 class AnalogEntanglement(AnalogBlock):
@@ -1098,30 +1134,6 @@ class AnalogEntanglement(AnalogBlock):
     @property
     def duration(self) -> Basic:
         return self.parameters.duration
-
-
-def _cast(T: Any, val: Any) -> Any:
-    return val if isinstance(val, T) else T(val)
-
-
-def wait(
-    duration: TNumber | sympy.Basic,
-    qubit_support: str | QubitSupport | tuple = "global",
-    add_pattern: bool = True,
-) -> WaitBlock:
-    """Constructs a [`WaitBlock`][qadence.blocks.analog.WaitBlock].
-
-    Arguments:
-        duration: Time to wait in nanoseconds.
-        qubit_support: Qubits the `WaitBlock` is applied to. Can be either
-            `"global"` to apply the wait block to all qubits or a tuple of integers.
-
-    Returns:
-        a `WaitBlock`
-    """
-    q = _cast(QubitSupport, qubit_support)
-    ps = ParamMap(duration=duration)
-    return WaitBlock(parameters=ps, qubit_support=q, add_pattern=add_pattern)
 
 
 def entangle(
@@ -1284,7 +1296,7 @@ analog_gateset = [
     AnalogRX,
     AnalogRY,
     AnalogRZ,
+    AnalogInteraction,
     entangle,
-    wait,
 ]
 non_unitary_gateset = [Zero, N, Projector]

--- a/qadence/types.py
+++ b/qadence/types.py
@@ -386,7 +386,7 @@ class OpName(StrEnum):
     """The analog RZ operation."""
     ANALOGSWAP = "AnalogSWAP"
     """The analog SWAP operation."""
-    ENTANGLE = "Entangle"
+    ENTANGLE = "entangle"
     """The entanglement operation."""
     ANALOGINTERACTION = "AnalogInteraction"
     """The analog interaction operation."""

--- a/qadence/types.py
+++ b/qadence/types.py
@@ -387,8 +387,8 @@ class OpName(StrEnum):
     """The analog SWAP operation."""
     ENTANG = "entangle"
     """The entanglement operation."""
-    WAIT = "wait"
-    """The wait operation."""
+    ANALOGINTERACTION = "AnalogInteraction"
+    """The analog interaction operation."""
     PROJ = "Projector"
     """The projector operation."""
 

--- a/qadence/types.py
+++ b/qadence/types.py
@@ -386,7 +386,7 @@ class OpName(StrEnum):
     """The analog RZ operation."""
     ANALOGSWAP = "AnalogSWAP"
     """The analog SWAP operation."""
-    ENTANG = "entangle"
+    ENTANGLE = "Entangle"
     """The entanglement operation."""
     ANALOGINTERACTION = "AnalogInteraction"
     """The analog interaction operation."""

--- a/tests/analog/test_analog_block.py
+++ b/tests/analog/test_analog_block.py
@@ -37,7 +37,7 @@ def test_qubit_support() -> None:
 def test_analog_block() -> None:
     b: AnalogBlock
     b = AnalogInteraction(duration=3, qubit_support=(1, 2))
-    assert b.__repr__() == "InteractionBlock(t=3.0, support=(1, 2))"
+    assert repr(b) == "InteractionBlock(t=3.0, support=(1, 2))"
 
     c1 = chain(
         ConstantAnalogRotation(parameters=ParamMap(duration=2000, omega=1, delta=0, phase=0)),

--- a/tests/analog/test_analog_block.py
+++ b/tests/analog/test_analog_block.py
@@ -37,7 +37,7 @@ def test_qubit_support() -> None:
 def test_analog_block() -> None:
     b: AnalogBlock
     b = AnalogInteraction(duration=3, qubit_support=(1, 2))
-    assert b.__repr__() == "WaitBlock(t=3.0, support=(1, 2))"
+    assert b.__repr__() == "InteractionBlock(t=3.0, support=(1, 2))"
 
     c1 = chain(
         ConstantAnalogRotation(parameters=ParamMap(duration=2000, omega=1, delta=0, phase=0)),

--- a/tests/analog/test_analog_emulation.py
+++ b/tests/analog/test_analog_emulation.py
@@ -14,13 +14,13 @@ from qadence.operations import (
     RX,
     RY,
     RZ,
+    AnalogInteraction,
     AnalogRot,
     AnalogRX,
     AnalogRY,
     AnalogRZ,
     chain,
     kron,
-    wait,
 )
 from qadence.overlap import js_divergence
 from qadence.register import Register
@@ -40,7 +40,7 @@ d = 3.75
         # FIXME: I commented this test because it was still running
         # and failing despite the pytest.mark.xfail.
         # pytest.param(  # enable with next pulser release
-        #     wait(duration=1), lambda n: I(n), marks=pytest.mark.xfail
+        #     AnalogInteraction(duration=1), lambda n: I(n), marks=pytest.mark.xfail
         # ),
         (AnalogRX(angle=pi), lambda n: layer(RX, n, pi)),
         (AnalogRY(angle=pi), lambda n: layer(RY, n, pi)),
@@ -76,12 +76,12 @@ def test_far_add_interaction(analog: AnalogBlock, digital_fn: Callable, register
     [
         AnalogRX(angle=pi),
         AnalogRY(angle=pi),
-        chain(wait(duration=2000), AnalogRX(angle=pi)),
+        chain(AnalogInteraction(duration=2000), AnalogRX(angle=pi)),
         chain(
             AnalogRot(duration=1000, omega=1.0, delta=0.0, phase=0),
             AnalogRot(duration=1000, omega=0.0, delta=1.0, phase=0),
         ),
-        kron(AnalogRX(pi, qubit_support=(0, 1)), wait(1000, qubit_support=(2, 3))),
+        kron(AnalogRX(pi, qubit_support=(0, 1)), AnalogInteraction(1000, qubit_support=(2, 3))),
     ],
 )
 @pytest.mark.parametrize("register", [Register.from_coordinates([(0, 5), (5, 5), (5, 0), (0, 0)])])
@@ -106,7 +106,7 @@ def test_mixing_digital_analog() -> None:
 
 # FIXME: Adapt when custom interaction functions are again supported
 # def test_custom_interaction_function() -> None:
-#     circuit = QuantumCircuit(2, wait(duration=100))
+#     circuit = QuantumCircuit(2, AnalogInteraction(duration=100))
 #     emulated = add_interaction(circuit, interaction=lambda reg, pairs: I(0))
 #     assert emulated.block == HamEvo(I(0), 100 / 1000)
 

--- a/tests/analog/test_pyq_vs_pulser.py
+++ b/tests/analog/test_pyq_vs_pulser.py
@@ -18,6 +18,7 @@ from qadence.operations import (
     RX,
     RY,
     RZ,
+    AnalogInteraction,
     AnalogRot,
     AnalogRX,
     AnalogRY,
@@ -26,7 +27,6 @@ from qadence.operations import (
     X,
     Z,
     entangle,
-    wait,
 )
 from qadence.parameters import FeatureParameter
 from qadence.register import Register
@@ -90,7 +90,7 @@ def test_parametrized_analog_rot(
 @pytest.mark.parametrize("n_qubits", [2, 3, 4])
 @pytest.mark.parametrize("spacing", [7.0, 10.0, 15.0])
 @pytest.mark.parametrize("rydberg_level", [60, 70])
-@pytest.mark.parametrize("op", [AnalogRX, AnalogRY, AnalogRZ, AnalogRot, wait])
+@pytest.mark.parametrize("op", [AnalogRX, AnalogRY, AnalogRZ, AnalogRot, AnalogInteraction])
 def test_analog_op_run(
     n_qubits: int, spacing: float, rydberg_level: int, op: AbstractBlock
 ) -> None:
@@ -146,16 +146,16 @@ def get_random_rot(param: str, qubit_support: tuple[int]) -> AbstractBlock:
         ),
         kron(
             get_random_rot("x", (1,)),
-            wait("x", qubit_support=(0, 2)),
+            AnalogInteraction("x", qubit_support=(0, 2)),
         ),
         chain(
             kron(
                 get_random_rot("x", (0,)),
-                wait("x", qubit_support=(1, 2)),
+                AnalogInteraction("x", qubit_support=(1, 2)),
             ),
             kron(
                 get_random_rot("x", (2,)),
-                wait("x", qubit_support=(0, 1)),
+                AnalogInteraction("x", qubit_support=(0, 1)),
             ),
         ),
     ],

--- a/tests/backends/pulser_basic/test_differentiation.py
+++ b/tests/backends/pulser_basic/test_differentiation.py
@@ -34,7 +34,7 @@ def block(circ_id: int) -> AbstractBlock:
             AnalogRot(duration=1000 * x / 3.0, omega=4.0, delta=3.0),
             # FIXME: Re-check these tests after handling:
             # https://github.com/pasqal-io/qadence/issues/266
-            # wait(500),
+            # AnalogInteraction(500),
             AnalogRX(np.pi / 2),
         )
 


### PR DESCRIPTION
I suggest to replace the `wait` alias operation with `AnalogInteraction` to be a bit more formal and explicit about what it does (it evolves the interaction term in the Hamiltonian for a register of interacting qubits).