### PR TITLE
Store the noise model when passed to sample method.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 ]
 requires-python = ">=3.9,<3.12"
 license = {text = "Apache 2.0"}
-version = "1.2.6"
+version = "1.2.7"
 classifiers=[
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",

--- a/qadence/models/quantum_model.py
+++ b/qadence/models/quantum_model.py
@@ -228,6 +228,8 @@ class QuantumModel(nn.Module):
             measurement = self._measurement
         if noise is None:
             noise = self._noise
+        else:
+            self._noise = noise
         if mitigation is None:
             mitigation = self._mitigation
         return self.backend.expectation(

--- a/qadence/models/quantum_model.py
+++ b/qadence/models/quantum_model.py
@@ -185,6 +185,8 @@ class QuantumModel(nn.Module):
         params = self.embedding_fn(self._params, values)
         if noise is None:
             noise = self._noise
+        else:
+            self._noise = noise
         if mitigation is None:
             mitigation = self._mitigation
         return self.backend.sample(


### PR DESCRIPTION
Store the noise model as QM class attribute for later retrieval when passed to methods.