### PR TITLE
[BugFix] Wrong tensor for control blocks, inefficient eigenvalues

### DIFF
--- a/qadence/blocks/primitive.py
+++ b/qadence/blocks/primitive.py
@@ -381,10 +381,6 @@ class ControlBlock(PrimitiveBlock):
     def __ascii__(self, console: Console) -> RenderableType:
         raise NotImplementedError
 
-    @property
-    def n_qubits(self) -> int:
-        return len(self.qubit_support)
-
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, AbstractBlock):
             raise TypeError(f"Cant compare {type(self)} to {type(other)}")

--- a/qadence/utils.py
+++ b/qadence/utils.py
@@ -6,7 +6,8 @@ from typing import Any
 
 import numpy as np
 import sympy
-from torch import Tensor, complex, stack, vmap
+from torch import Tensor, stack, vmap
+from torch import complex as make_complex
 from torch.linalg import eigvals
 
 from qadence.logger import get_logger
@@ -207,7 +208,7 @@ def _round_complex(t: Tensor, decimals: int = 4) -> Tensor:
     def _round(_t: Tensor) -> Tensor:
         r = _t.real.round(decimals=decimals)
         i = _t.imag.round(decimals=decimals)
-        return complex(r, i)
+        return make_complex(r, i)
 
     fn = vmap(_round)
     return fn(t)

--- a/qadence/utils.py
+++ b/qadence/utils.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import numpy as np
 import sympy
-import torch
+from torch import Tensor, complex, stack, vmap
 from torch.linalg import eigvals
 
 from qadence.logger import get_logger
@@ -86,7 +86,7 @@ def nqubits_to_basis(
     n_qubits: int,
     result_type: ResultType = ResultType.STRING,
     endianness: Endianness = Endianness.BIG,
-) -> list[str] | torch.Tensor | np.array:
+) -> list[str] | Tensor | np.array:
     """
     Creates all basis states for a given number of qubits, endianness and format.
 
@@ -112,7 +112,7 @@ def nqubits_to_basis(
     else:
         basis_list = [list(map(int, tuple(basis))) for basis in basis_strings]
         if result_type == ResultType.TORCH:
-            return torch.stack([torch.tensor(basis) for basis in basis_list])
+            return stack([Tensor(basis) for basis in basis_list])
         elif result_type == ResultType.NUMPY:
             return np.stack([np.array(basis) for basis in basis_list])
 
@@ -177,43 +177,43 @@ def isclose(
     if isinstance(x, complex) or isinstance(y, complex):
         return abs(x - y) <= max(rel_tol * max(abs(x), abs(y)), abs_tol)  # type: ignore
 
-    return math.isclose(x, y, rel_tol=rel_tol, abs_tol=abs_tol)
+    return math.isclose(x, y, rel_tol=rel_tol, abs_tol=abs_tol)  # type: ignore
 
 
 def eigenvalues(
-    x: torch.Tensor, max_num_evals: int | None = None, max_num_gaps: int | None = None
-) -> torch.Tensor:
+    x: Tensor, max_num_evals: int | None = None, max_num_gaps: int | None = None
+) -> Tensor:
     # FIXME: Currently doing full decomposition everytime because it is generally faster
-    # than converting to numpy and using the scipy routines for "top-k" eigenvalues.
+    # than converting to numpy and using the scipy routines to select first k-eigenvalues.
     # Furthermore, we should exploit the matrices being Hermitian.
 
     # get all eigenvalues of generator
-    eigenvals_full = eigvals(x).squeeze(0)
+    eigenspectrum = eigvals(x).squeeze(0)
 
     if max_num_evals and not max_num_gaps:
         # get specified number of eigenvalues of generator
-        eigenvals = eigenvals_full[:max_num_evals]
+        eigenvals = eigenspectrum[:max_num_evals]
     elif max_num_gaps and not max_num_evals:
         # get eigenvalues of generator corresponding to specified number of spectral gaps
         k = int(np.ceil(0.5 * (1 + np.sqrt(1 + 8 * max_num_gaps))))
-        eigenvals = eigenvals_full[:k]
+        eigenvals = eigenspectrum[:k]
     else:
-        eigenvals = eigenvals_full
+        eigenvals = eigenspectrum
 
     return eigenvals
 
 
-def _round_complex(t: torch.Tensor, decimals: int = 4) -> torch.Tensor:
-    def _round(_t: torch.Tensor) -> torch.Tensor:
+def _round_complex(t: Tensor, decimals: int = 4) -> Tensor:
+    def _round(_t: Tensor) -> Tensor:
         r = _t.real.round(decimals=decimals)
         i = _t.imag.round(decimals=decimals)
-        return torch.complex(r, i)
+        return complex(r, i)
 
-    fn = torch.vmap(_round)
+    fn = vmap(_round)
     return fn(t)
 
 
-def is_qadence_shape(state: torch.Tensor, n_qubits: int) -> bool:
+def is_qadence_shape(state: Tensor, n_qubits: int) -> bool:
     if len(state.size()) < 2:
         raise ValueError(
             f"Provided state is required to have atleast two dimensions. Got shape {state.shape}"
@@ -221,7 +221,7 @@ def is_qadence_shape(state: torch.Tensor, n_qubits: int) -> bool:
     return state.shape[1] == 2**n_qubits  # type: ignore[no-any-return]
 
 
-def infer_batchsize(param_values: dict[str, torch.Tensor] = None) -> int:
+def infer_batchsize(param_values: dict[str, Tensor] = None) -> int:
     """Infer the batch_size through the length of the parameter tensors."""
     try:
         return max([len(tensor) for tensor in param_values.values()]) if param_values else 1
@@ -230,7 +230,7 @@ def infer_batchsize(param_values: dict[str, torch.Tensor] = None) -> int:
 
 
 def validate_values_and_state(
-    state: torch.Tensor | None, n_qubits: int, param_values: dict[str, torch.Tensor] = None
+    state: Tensor | None, n_qubits: int, param_values: dict[str, Tensor] = None
 ) -> None:
     if state is not None:
         batch_size_state = (

--- a/tests/qadence/test_matrices.py
+++ b/tests/qadence/test_matrices.py
@@ -691,6 +691,13 @@ def test_swap_cnot_gates(gate: AbstractBlock, n_qubits: int) -> None:
     assert equivalent_state(wf_pyq, wf_mat, atol=ATOL_32)
 
 
+def test_cnot_support() -> None:
+    mat_full = block_to_tensor(CNOT(0, 2), use_full_support=True)
+    mat_small = block_to_tensor(CNOT(0, 2), use_full_support=False)
+    assert len(mat_full.squeeze(0)) == 8
+    assert len(mat_small.squeeze(0)) == 4
+
+
 @pytest.mark.parametrize("n_qubits", [3, 4, 6])
 def test_cswap_gate(n_qubits: int) -> None:
     control, target1, target2 = np.random.choice(


### PR DESCRIPTION
See https://github.com/pasqal-io/qadence/issues/320 for context on eigenvalues change.

Furthermore a recent change to the control blocks made `block_to_tensor` give incorrect results for non-sequential qubit supports, which was not tested.