### PR TITLE
[Refac] Add 'device' to ml_tools optimize_step

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 ]
 requires-python = ">=3.9,<3.12"
 license = {text = "Apache 2.0"}
-version = "1.3.0"
+version = "1.3.2"
 classifiers=[
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 ]
 requires-python = ">=3.9,<3.12"
 license = {text = "Apache 2.0"}
-version = "1.3.2"
+version = "1.4.0"
 classifiers=[
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",

--- a/qadence/ml_tools/data.py
+++ b/qadence/ml_tools/data.py
@@ -86,15 +86,40 @@ def data_to_device(xs: Any, device: str) -> Any:
 
 
 @data_to_device.register
+def _(xs: None, device: str) -> None:
+    return xs
+
+
+@data_to_device.register(Tensor)
 def _(xs: Tensor, device: str) -> Tensor:
-    return xs.to(device, non_blocking=True)
+    return xs.to(device=device, non_blocking=True)
 
 
-@data_to_device.register
+@data_to_device.register(list)
 def _(xs: list, device: str) -> list:
     return [data_to_device(x, device) for x in xs]
 
 
-@data_to_device.register
+@data_to_device.register(dict)
 def _(xs: dict, device: str) -> dict:
     return {key: data_to_device(val, device) for key, val in xs.items()}
+
+
+@data_to_device.register(DataLoader)
+def _(xs: DataLoader, device: str) -> DataLoader:
+    return DataLoader(data_to_device(xs.dataset, device))
+
+
+@data_to_device.register(DictDataLoader)
+def _(xs: DictDataLoader, device: str) -> DictDataLoader:
+    return DictDataLoader({key: data_to_device(val, device) for key, val in xs.dataloaders.items()})
+
+
+@data_to_device.register(InfiniteTensorDataset)
+def _(xs: InfiniteTensorDataset, device: str) -> InfiniteTensorDataset:
+    return InfiniteTensorDataset(*[data_to_device(val, device) for val in xs.tensors])
+
+
+@data_to_device.register(TensorDataset)
+def _(xs: TensorDataset, device: str) -> TensorDataset:
+    return TensorDataset(*[data_to_device(val, device) for val in xs.tensors])

--- a/qadence/ml_tools/data.py
+++ b/qadence/ml_tools/data.py
@@ -5,7 +5,8 @@ from functools import singledispatch
 from itertools import cycle
 from typing import Any, Iterator
 
-from torch import Tensor, device
+from torch import Tensor
+from torch import device as torch_device
 from torch.utils.data import DataLoader, IterableDataset, TensorDataset
 
 
@@ -81,45 +82,45 @@ def to_dataloader(*tensors: Tensor, batch_size: int = 1, infinite: bool = False)
 
 
 @singledispatch
-def data_to_device(xs: Any, device: device | str | None) -> Any:
+def data_to_device(xs: Any, device: torch_device) -> Any:
     raise ValueError(f"Cannot move {type(xs)} to a pytorch device.")
 
 
 @data_to_device.register
-def _(xs: None, device: device | str | None) -> None:
+def _(xs: None, device: torch_device) -> None:
     return xs
 
 
 @data_to_device.register(Tensor)
-def _(xs: Tensor, device: device | str | None) -> Tensor:
+def _(xs: Tensor, device: torch_device) -> Tensor:
     return xs.to(device=device, non_blocking=True)
 
 
 @data_to_device.register(list)
-def _(xs: list, device: device | str | None) -> list:
+def _(xs: list, device: torch_device) -> list:
     return [data_to_device(x, device) for x in xs]
 
 
 @data_to_device.register(dict)
-def _(xs: dict, device: device | str | None) -> dict:
+def _(xs: dict, device: torch_device) -> dict:
     return {key: data_to_device(val, device) for key, val in xs.items()}
 
 
 @data_to_device.register(DataLoader)
-def _(xs: DataLoader, device: device | str | None) -> DataLoader:
+def _(xs: DataLoader, device: torch_device) -> DataLoader:
     return DataLoader(data_to_device(xs.dataset, device))
 
 
 @data_to_device.register(DictDataLoader)
-def _(xs: DictDataLoader, device: device | str | None) -> DictDataLoader:
+def _(xs: DictDataLoader, device: torch_device) -> DictDataLoader:
     return DictDataLoader({key: data_to_device(val, device) for key, val in xs.dataloaders.items()})
 
 
 @data_to_device.register(InfiniteTensorDataset)
-def _(xs: InfiniteTensorDataset, device: device | str | None) -> InfiniteTensorDataset:
+def _(xs: InfiniteTensorDataset, device: torch_device) -> InfiniteTensorDataset:
     return InfiniteTensorDataset(*[data_to_device(val, device) for val in xs.tensors])
 
 
 @data_to_device.register(TensorDataset)
-def _(xs: TensorDataset, device: device | str | None) -> TensorDataset:
+def _(xs: TensorDataset, device: torch_device) -> TensorDataset:
     return TensorDataset(*[data_to_device(val, device) for val in xs.tensors])

--- a/qadence/ml_tools/data.py
+++ b/qadence/ml_tools/data.py
@@ -83,6 +83,7 @@ def to_dataloader(*tensors: Tensor, batch_size: int = 1, infinite: bool = False)
 
 @singledispatch
 def data_to_device(xs: Any, device: torch_device) -> Any:
+    """Utility method to move arbitrary data to 'device'."""
     raise ValueError(f"Cannot move {type(xs)} to a pytorch device.")
 
 

--- a/qadence/ml_tools/optimize_step.py
+++ b/qadence/ml_tools/optimize_step.py
@@ -6,12 +6,15 @@ import torch
 from torch.nn import Module
 from torch.optim import Optimizer
 
+from qadence.ml_tools.data import data_to_device
+
 
 def optimize_step(
     model: Module,
     optimizer: Optimizer,
     loss_fn: Callable,
     xs: dict | list | torch.Tensor | None,
+    device: torch.device = torch.device("cpu"),
 ) -> tuple[torch.Tensor | float, dict | None]:
     """Default Torch optimize step with closure.
 
@@ -31,6 +34,7 @@ def optimize_step(
     """
 
     loss, metrics = None, {}
+    xs_to_device = data_to_device(xs, device)
 
     def closure() -> Any:
         # NOTE: We need the nonlocal as we can't return a metric dict and
@@ -38,7 +42,7 @@ def optimize_step(
         # reason the returned loss is always the first one...
         nonlocal metrics, loss
         optimizer.zero_grad()
-        loss, metrics = loss_fn(model, xs)
+        loss, metrics = loss_fn(model, xs_to_device)
         loss.backward(retain_graph=True)
         return loss.item()
 

--- a/qadence/ml_tools/optimize_step.py
+++ b/qadence/ml_tools/optimize_step.py
@@ -14,7 +14,7 @@ def optimize_step(
     optimizer: Optimizer,
     loss_fn: Callable,
     xs: dict | list | torch.Tensor | None,
-    device: torch.device = torch.device("cpu"),
+    device: torch.device = None,
 ) -> tuple[torch.Tensor | float, dict | None]:
     """Default Torch optimize step with closure.
 

--- a/qadence/ml_tools/optimize_step.py
+++ b/qadence/ml_tools/optimize_step.py
@@ -27,6 +27,7 @@ def optimize_step(
         loss_fn (Callable): A custom loss function
         xs (dict | list | torch.Tensor | None): the input data. If None it means
             that the given model does not require any input data
+        device (torch.device): A target device to run computation on.
 
     Returns:
         tuple: tuple containing the model, the optimizer, a dictionary with

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -10,7 +10,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 from qadence.logger import get_logger
 from qadence.ml_tools.config import TrainConfig
-from qadence.ml_tools.data import DictDataLoader, data_to_device
+from qadence.ml_tools.data import DictDataLoader
 from qadence.ml_tools.optimize_step import optimize_step
 from qadence.ml_tools.printing import print_metrics, write_tensorboard
 from qadence.ml_tools.saveload import load_checkpoint, write_checkpoint
@@ -139,12 +139,19 @@ def train(
                 # this is the case, for example, of quantum models
                 # which do not have classical input data (e.g. chemistry)
                 if dataloader is None:
-                    loss, metrics = optimize_step(model, optimizer, loss_fn, None)
+                    loss, metrics = optimize_step(
+                        model=model, optimizer=optimizer, loss_fn=loss_fn, xs=None, device=device
+                    )
                     loss = loss.item()
 
                 elif isinstance(dataloader, (DictDataLoader, DataLoader)):
-                    data = data_to_device(next(dl_iter), device)  # type: ignore[arg-type]
-                    loss, metrics = optimize_step(model, optimizer, loss_fn, data)
+                    loss, metrics = optimize_step(
+                        model=model,
+                        optimizer=optimizer,
+                        loss_fn=loss_fn,
+                        xs=next(dl_iter),  # type: ignore[arg-type]
+                        device=device,
+                    )
 
                 else:
                     raise NotImplementedError(

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Callable, Union
 
 from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeRemainingColumn
+from torch import device as torch_device
 from torch.nn import DataParallel, Module
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
@@ -24,7 +25,7 @@ def train(
     optimizer: Optimizer,
     config: TrainConfig,
     loss_fn: Callable,
-    device: str = "cpu",
+    device: torch_device = None,
     optimize_step: Callable = optimize_step,
     write_tensorboard: Callable = write_tensorboard,
 ) -> tuple[Module, Optimizer]:


### PR DESCRIPTION
To avoid having to let the user move arbitary (custom) data loader types to the device, we reintroduce the 'device' arg to `optimize_step` which uses `data_to_device` method which supports a variety of qadence-compatible data types.