### PR TITLE
[Infra] Make function in various extension packages available from the qadence namespace

### DIFF
--- a/qadence/__init__.py
+++ b/qadence/__init__.py
@@ -28,6 +28,21 @@ from .transpile import *
 from .types import *
 from .utils import *
 
+"""Manage imports from extension packages:
+
+For each extension package, tries to import the functions defined in the __all__, making
+them available in the qadence namespace.
+"""
+try:
+    from qadence_libs import *
+except ModuleNotFoundError:
+    pass
+
+# try:
+#    from qadence_protocols import *
+# except ModuleNotFoundError:
+#    pass
+
 DEFAULT_FLOAT_DTYPE = torchfloat64
 DEFAULT_COMPLEX_DTYPE = cdouble
 set_default_dtype(DEFAULT_FLOAT_DTYPE)


### PR DESCRIPTION
@Roland-djee @dominikandreasseitz this was just a quick test and it does seem to work. To be discussed if we want it or not. This makes functions moved out of Qadence that are currently imported from the Qadence namespace to continue available in `from qadence import XXX`, but it does imply some nuances in how the deprecation of these functions in Qadence should be communicated and how users should update their scripts. For example, once we remove `hea` from Qadence, `from qadence import hea` would continue to work, but `from qadence.constructors import hea` would break.