### PR TITLE
[Refac] Add device to model checkpoints

### DIFF
--- a/qadence/ml_tools/models.py
+++ b/qadence/ml_tools/models.py
@@ -310,3 +310,11 @@ class TransformedModule(torch.nn.Module):
         except Exception as e:
             logger.warning(f"Unable to move {self} to {args}, {kwargs} due to {e}.")
         return self
+
+    @property
+    def device(self) -> torch.device:
+        return (
+            self.model.device
+            if isinstance(self.model, QuantumModel)
+            else self._input_scaling.device
+        )

--- a/qadence/ml_tools/saveload.py
+++ b/qadence/ml_tools/saveload.py
@@ -61,7 +61,7 @@ def write_checkpoint(
     device = None
     try:
         # We extract the device from the pyqtorch native circuit
-        device = model.device
+        device = str(model.device).split(":")[0]  # in case of using several CUDA devices
     except Exception:
         pass
     model_checkpoint_name: str = (

--- a/qadence/ml_tools/saveload.py
+++ b/qadence/ml_tools/saveload.py
@@ -58,8 +58,18 @@ def write_checkpoint(
     from qadence.ml_tools.models import TransformedModule
     from qadence.models import QNN, QuantumModel
 
-    model_checkpoint_name: str = f"model_{type(model).__name__}_ckpt_" + f"{iteration:03n}" + ".pt"
-    opt_checkpoint_name: str = f"opt_{type(optimizer).__name__}_ckpt_" + f"{iteration:03n}" + ".pt"
+    device = None
+    try:
+        # We extract the device from the pyqtorch native circuit
+        device = model.device
+    except Exception:
+        pass
+    model_checkpoint_name: str = (
+        f"model_{type(model).__name__}_ckpt_" + f"{iteration:03n}" + f"_device_{device}" + ".pt"
+    )
+    opt_checkpoint_name: str = (
+        f"opt_{type(optimizer).__name__}_ckpt_" + f"{iteration:03n}" + f"_device_{device}" + ".pt"
+    )
     try:
         d = (
             model._to_dict(save_params=True)

--- a/qadence/models/quantum_model.py
+++ b/qadence/models/quantum_model.py
@@ -364,3 +364,11 @@ class QuantumModel(nn.Module):
         except Exception as e:
             logger.warning(f"Unable to move {self} to {args}, {kwargs} due to {e}.")
         return self
+
+    @property
+    def device(self) -> torch.device:
+        return (
+            self._circuit.native.device
+            if self.backend.backend.name == "pyqtorch"  # type: ignore[union-attr]
+            else torch.device("cpu")
+        )

--- a/tests/ml_tools/test_checkpointing.py
+++ b/tests/ml_tools/test_checkpointing.py
@@ -71,8 +71,8 @@ def test_random_basicqQM_save_load_ckpts(BasicQuantumModel: QuantumModel, tmp_pa
         tmp_path,
         BasicQuantumModel,
         optimizer,
-        "model_QuantumModel_ckpt_009.pt",
-        "opt_Adam_ckpt_006.pt",
+        "model_QuantumModel_ckpt_009_device_cpu.pt",
+        "opt_Adam_ckpt_006_device_cpu.pt",
     )
     assert torch.allclose(loaded_model.expectation({}), model.expectation({}))
 
@@ -92,7 +92,7 @@ def test_check_ckpts_exist(BasicQuantumModel: QuantumModel, tmp_path: Path) -> N
 
     config = TrainConfig(folder=tmp_path, max_iter=10, checkpoint_every=1, write_every=1)
     train_with_grad(model, data, optimizer, config, loss_fn=loss_fn)
-    ckpts = [tmp_path / Path(f"model_QuantumModel_ckpt_00{i}.pt") for i in range(1, 9)]
+    ckpts = [tmp_path / Path(f"model_QuantumModel_ckpt_00{i}_device_cpu.pt") for i in range(1, 9)]
     assert all(os.path.isfile(ckpt) for ckpt in ckpts)
     for ckpt in ckpts:
         loaded_model, optimizer, _ = load_checkpoint(
@@ -123,8 +123,8 @@ def test_random_basicqQNN_save_load_ckpts(BasicQNN: QNN, tmp_path: Path) -> None
         tmp_path,
         BasicQNN,
         optimizer,
-        "model_QNN_ckpt_009.pt",
-        "opt_Adam_ckpt_006.pt",
+        "model_QNN_ckpt_009_device_cpu.pt",
+        "opt_Adam_ckpt_006_device_cpu.pt",
     )
     assert torch.allclose(loaded_model.expectation(inputs), model.expectation(inputs))
 
@@ -145,7 +145,7 @@ def test_check_QNN_ckpts_exist(BasicQNN: QNN, tmp_path: Path) -> None:
 
     config = TrainConfig(folder=tmp_path, max_iter=10, checkpoint_every=1, write_every=1)
     train_with_grad(model, data, optimizer, config, loss_fn=loss_fn)
-    ckpts = [tmp_path / Path(f"model_QNN_ckpt_00{i}.pt") for i in range(1, 9)]
+    ckpts = [tmp_path / Path(f"model_QNN_ckpt_00{i}_device_cpu.pt") for i in range(1, 9)]
     assert all(os.path.isfile(ckpt) for ckpt in ckpts)
     for ckpt in ckpts:
         loaded_model, optimizer, _ = load_checkpoint(tmp_path, BasicQNN, optimizer, ckpt, "")
@@ -176,7 +176,7 @@ def test_random_basicqtransformedmodule_save_load_ckpts(
         tmp_path,
         BasicTransformedModule,
         optimizer,
-        "model_TransformedModule_ckpt_009.pt",
+        "model_TransformedModule_ckpt_009_device_cpu.pt",
         "opt_Adam_ckpt_006.pt",
     )
     assert torch.allclose(loaded_model.expectation(inputs), model.expectation(inputs))
@@ -200,7 +200,9 @@ def test_check_transformedmodule_ckpts_exist(
 
     config = TrainConfig(folder=tmp_path, max_iter=10, checkpoint_every=1, write_every=1)
     train_with_grad(model, data, optimizer, config, loss_fn=loss_fn)
-    ckpts = [tmp_path / Path(f"model_TransformedModule_ckpt_00{i}.pt") for i in range(1, 9)]
+    ckpts = [
+        tmp_path / Path(f"model_TransformedModule_ckpt_00{i}_device_cpu.pt") for i in range(1, 9)
+    ]
     assert all(os.path.isfile(ckpt) for ckpt in ckpts)
     for ckpt in ckpts:
         loaded_model, optimizer, _ = load_checkpoint(


### PR DESCRIPTION
When training the same model twice, however on different devices, `train_grad` fails due to the checkpoints differing in devices. This MR adds a "device" suffix to each created checkpoint