### PR TITLE
Cm/log tensorboard

### DIFF
--- a/qadence/ml_tools/printing.py
+++ b/qadence/ml_tools/printing.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from math import isnan
+
 from torch.utils.tensorboard import SummaryWriter
 
 
@@ -12,7 +14,8 @@ def print_metrics(loss: float | None, metrics: dict, iteration: int) -> None:
 
 
 def write_tensorboard(writer: SummaryWriter, loss: float, metrics: dict, iteration: int) -> None:
-    writer.add_scalar("loss", loss, iteration)
+    if not isnan(loss):
+        writer.add_scalar("loss", loss, iteration)
     for key, arg in metrics.items():
         writer.add_scalar(key, arg, iteration)
 

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -154,12 +154,32 @@ def train(
         data_dtype = float64 if dtype == complex128 else float32
 
     best_val_loss = math.inf
+
     with progress:
         dl_iter = iter(dataloader) if dataloader is not None else None
-        if perform_val:
-            dl_iter_val = iter(val_dataloader) if val_dataloader is not None else None
+
+        # Initial validation evaluation
+        try:
+            if perform_val:
+                dl_iter_val = iter(val_dataloader) if val_dataloader is not None else None
+                xs = next(dl_iter_val)
+                xs_to_device = data_to_device(xs, device=device, dtype=data_dtype)
+                best_val_loss, metrics = loss_fn(model, xs_to_device)
+
+                metrics["val_loss"] = best_val_loss
+                write_tensorboard(writer, math.nan, metrics, init_iter)
+
+            if config.folder:
+                if config.checkpoint_best_only:
+                    write_checkpoint(config.folder, model, optimizer, iteration="best")
+                else:
+                    write_checkpoint(config.folder, model, optimizer, init_iter)
+
+        except KeyboardInterrupt:
+            logger.info("Terminating training gracefully after the current iteration.")
 
         # outer epoch loop
+        init_iter += 1
         for iteration in progress.track(range(init_iter, init_iter + config.max_iter)):
             try:
                 # in case there is not data needed by the model
@@ -193,10 +213,13 @@ def train(
                     )
 
                 if iteration % config.print_every == 0 and config.verbose:
-                    print_metrics(loss, metrics, iteration)
+                    # Note that the loss returned by optimize_step
+                    # is the value before doing the training step
+                    # which is printed accordingly by the previous iteration number
+                    print_metrics(loss, metrics, iteration - 1)
 
                 if iteration % config.write_every == 0:
-                    write_tensorboard(writer, loss, metrics, iteration)
+                    write_tensorboard(writer, loss, metrics, iteration - 1)
 
                 if perform_val:
                     if iteration % config.val_every == 0:
@@ -217,8 +240,19 @@ def train(
             except KeyboardInterrupt:
                 logger.info("Terminating training gracefully after the current iteration.")
                 break
+        try:
+            xs = next(dl_iter)  # type: ignore[arg-type]
+            xs_to_device = data_to_device(xs, device=device, dtype=data_dtype)
+            loss, metrics = loss_fn(model, xs_to_device)
+            if "val_loss" in metrics:
+                del metrics["val_loss"]
+            if iteration % config.print_every == 0 and config.verbose:
+                print_metrics(loss, metrics, iteration)
 
-    # Final writing and checkpointing
+        except KeyboardInterrupt:
+            logger.info("Terminating training gracefully after the current iteration.")
+
+    # Final printing, writing and checkpointing
     if config.folder and not config.checkpoint_best_only:
         write_checkpoint(config.folder, model, optimizer, iteration)
     write_tensorboard(writer, loss, metrics, iteration)

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -241,7 +241,7 @@ def train(
                 logger.info("Terminating training gracefully after the current iteration.")
                 break
         try:
-            xs = next(dl_iter)  # type: ignore[arg-type]
+            xs = next(dl_iter) if dataloader is not None else None  # type: ignore[arg-type]
             xs_to_device = data_to_device(xs, device=device, dtype=data_dtype)
             loss, metrics = loss_fn(model, xs_to_device)
             if "val_loss" in metrics:

--- a/tests/ml_tools/test_train.py
+++ b/tests/ml_tools/test_train.py
@@ -83,7 +83,7 @@ def test_train_dataloader_default(tmp_path: Path, Basic: torch.nn.Module) -> Non
     n_epochs = 100
     config = TrainConfig(folder=tmp_path, max_iter=n_epochs, checkpoint_every=100, write_every=100)
     train_with_grad(model, data, optimizer, config, loss_fn=loss_fn)
-    assert next(cnt) == n_epochs
+    assert next(cnt) == (n_epochs + 1)
 
     x = torch.rand(5, 1)
     assert torch.allclose(torch.sin(x), model(x), rtol=1e-1, atol=1e-1)
@@ -112,7 +112,7 @@ def test_train_dataloader_no_data(tmp_path: Path, BasicNoInput: torch.nn.Module)
         write_every=100,
     )
     train_with_grad(model, data, optimizer, config, loss_fn=loss_fn)
-    assert next(cnt) == n_epochs
+    assert next(cnt) == (n_epochs + 1)
 
     out = model()
     assert torch.allclose(out, torch.zeros(1), atol=1e-2, rtol=1e-2)
@@ -141,7 +141,7 @@ def test_train_dictdataloader(tmp_path: Path, Basic: torch.nn.Module) -> None:
         folder=tmp_path, max_iter=n_epochs, print_every=10, checkpoint_every=100, write_every=100
     )
     train_with_grad(model, data, optimizer, config, loss_fn=loss_fn)
-    assert next(cnt) == n_epochs
+    assert next(cnt) == (n_epochs + 1)
 
     x = torch.rand(5, 1)
     assert torch.allclose(torch.sin(x), model(x), rtol=1e-1, atol=1e-1)
@@ -199,7 +199,7 @@ def test_train_tensor_tuple(Basic: torch.nn.Module, BasicQNN: QNN) -> None:
         )
         data = to_dataloader(x, y, batch_size=batch_size, infinite=True)
         model, _ = train_with_grad(model, data, optimizer, config, loss_fn=loss_fn, dtype=dtype)
-        assert next(cnt) == n_epochs
+        assert next(cnt) == (n_epochs + 1)
 
         x = torch.rand(5, 1, dtype=torch.float32)
         assert torch.allclose(torch.sin(x), model(x), rtol=1e-1, atol=1e-1)
@@ -305,7 +305,7 @@ def test_train_dictdataloader_checkpoint_best_only(tmp_path: Path, Basic: torch.
 
     config = get_train_config_validation(tmp_path, n_epochs, checkpoint_every, val_every)
     train_with_grad(model, data, optimizer, config, loss_fn=loss_fn)
-    assert next(cnt) == n_epochs + n_epochs // val_every
+    assert next(cnt) == 2 + n_epochs + n_epochs // val_every
 
     files = [f for f in os.listdir(tmp_path) if f.endswith(".pt") and "model" in f]
     # Ideally it can be ensured if the (only) saved checkpoint is indeed the best,


### PR DESCRIPTION
Related to Issue #444 : 

- Fixing tensorboard logs to always include the loss/metrics values at iteration 0 (evaluating models before training) and fix inconsistencies wrt iteration numbers when logging training and validation values.
- Avoiding logging math.nan in tensorboard for the training loss.