### PR TITLE
[FIX] Allow 0 to be passed as a config to print,write,plot,checkpoint_every and disable in that case

### DIFF
--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -15,15 +15,9 @@ from qadence.blocks.analog import AnalogBlock
 from qadence.blocks.primitive import ParametricBlock
 from qadence.operations import RX, AnalogRX
 from qadence.parameters import Parameter
-from qadence.types import (
-    AnsatzType,
-    BasisSet,
-    ExperimentTrackingTool,
-    LoggablePlotFunction,
-    MultivariateStrategy,
-    ReuploadScaling,
-    Strategy,
-)
+from qadence.types import (AnsatzType, BasisSet, ExperimentTrackingTool,
+                           LoggablePlotFunction, MultivariateStrategy,
+                           ReuploadScaling, Strategy)
 
 logger = getLogger(__file__)
 
@@ -45,13 +39,13 @@ class TrainConfig:
     max_iter: int = 10000
     """Number of training iterations."""
     print_every: int = 1000
-    """Print loss/metrics."""
+    """Print loss/metrics. Set to 0 to disable"""
     write_every: int = 50
-    """Write loss and metrics with the tracking tool."""
+    """Write loss and metrics with the tracking tool. Set to 0 to disable"""
     checkpoint_every: int = 5000
-    """Write model/optimizer checkpoint."""
+    """Write model/optimizer checkpoint. Set to 0 to disable"""
     plot_every: int = 5000
-    """Write figures."""
+    """Write figures. Set to 0 to disable"""
     log_model: bool = False
     """Logs a serialised version of the model."""
     folder: Path | None = None

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -15,9 +15,15 @@ from qadence.blocks.analog import AnalogBlock
 from qadence.blocks.primitive import ParametricBlock
 from qadence.operations import RX, AnalogRX
 from qadence.parameters import Parameter
-from qadence.types import (AnsatzType, BasisSet, ExperimentTrackingTool,
-                           LoggablePlotFunction, MultivariateStrategy,
-                           ReuploadScaling, Strategy)
+from qadence.types import (
+    AnsatzType,
+    BasisSet,
+    ExperimentTrackingTool,
+    LoggablePlotFunction,
+    MultivariateStrategy,
+    ReuploadScaling,
+    Strategy,
+)
 
 logger = getLogger(__file__)
 
@@ -39,13 +45,25 @@ class TrainConfig:
     max_iter: int = 10000
     """Number of training iterations."""
     print_every: int = 1000
-    """Print loss/metrics. Set to 0 to disable"""
+    """Print loss/metrics.
+
+    Set to 0 to disable
+    """
     write_every: int = 50
-    """Write loss and metrics with the tracking tool. Set to 0 to disable"""
+    """Write loss and metrics with the tracking tool.
+
+    Set to 0 to disable
+    """
     checkpoint_every: int = 5000
-    """Write model/optimizer checkpoint. Set to 0 to disable"""
+    """Write model/optimizer checkpoint.
+
+    Set to 0 to disable
+    """
     plot_every: int = 5000
-    """Write figures. Set to 0 to disable"""
+    """Write figures.
+
+    Set to 0 to disable
+    """
     log_model: bool = False
     """Logs a serialised version of the model."""
     folder: Path | None = None

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -5,16 +5,12 @@ import math
 from logging import getLogger
 from typing import Callable, Union
 
-from rich.progress import (
-    BarColumn,
-    Progress,
-    TaskProgressColumn,
-    TextColumn,
-    TimeRemainingColumn,
-)
-from torch import complex128, float32, float64
+from rich.progress import (BarColumn, Progress, TaskProgressColumn, TextColumn,
+                           TimeRemainingColumn)
+from torch import complex128
 from torch import device as torch_device
 from torch import dtype as torch_dtype
+from torch import float32, float64
 from torch.nn import DataParallel, Module
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
@@ -23,13 +19,9 @@ from torch.utils.tensorboard import SummaryWriter
 from qadence.ml_tools.config import TrainConfig
 from qadence.ml_tools.data import DictDataLoader, data_to_device
 from qadence.ml_tools.optimize_step import optimize_step
-from qadence.ml_tools.printing import (
-    log_model_tracker,
-    log_tracker,
-    plot_tracker,
-    print_metrics,
-    write_tracker,
-)
+from qadence.ml_tools.printing import (log_model_tracker, log_tracker,
+                                       plot_tracker, print_metrics,
+                                       write_tracker)
 from qadence.ml_tools.saveload import load_checkpoint, write_checkpoint
 from qadence.types import ExperimentTrackingTool
 
@@ -231,18 +223,22 @@ def train(
                         "You can use e.g. `qadence.ml_tools.to_dataloader` to build a dataloader."
                     )
 
-                if iteration % config.print_every == 0 and config.verbose:
+                if (
+                    config.print_every != 0
+                    and iteration % config.print_every == 0
+                    and config.verbose
+                ):
                     # Note that the loss returned by optimize_step
                     # is the value before doing the training step
                     # which is printed accordingly by the previous iteration number
                     print_metrics(loss, metrics, iteration - 1)
 
-                if iteration % config.write_every == 0:
+                if config.write_every != 0 and iteration % config.write_every == 0:
                     write_tracker(
                         writer, loss, metrics, iteration, tracking_tool=config.tracking_tool
                     )
 
-                if iteration % config.plot_every == 0:
+                if config.plot_every != 0 and iteration % config.plot_every == 0:
                     plot_tracker(
                         writer,
                         model,
@@ -265,7 +261,11 @@ def train(
                             )
 
                 if config.folder:
-                    if iteration % config.checkpoint_every == 0 and not config.checkpoint_best_only:
+                    if (
+                        config.checkpoint_every != 0
+                        and iteration % config.checkpoint_every == 0
+                        and not config.checkpoint_best_only
+                    ):
                         write_checkpoint(config.folder, model, optimizer, iteration)
 
             except KeyboardInterrupt:

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -226,7 +226,7 @@ def train(
                     )
 
                 if (
-                    config.print_every != 0
+                    config.print_every > 0
                     and iteration % config.print_every == 0
                     and config.verbose
                 ):
@@ -235,12 +235,12 @@ def train(
                     # which is printed accordingly by the previous iteration number
                     print_metrics(loss, metrics, iteration - 1)
 
-                if config.write_every != 0 and iteration % config.write_every == 0:
+                if config.write_every > 0 and iteration % config.write_every == 0:
                     write_tracker(
                         writer, loss, metrics, iteration, tracking_tool=config.tracking_tool
                     )
 
-                if config.plot_every != 0 and iteration % config.plot_every == 0:
+                if config.plot_every > 0 and iteration % config.plot_every == 0:
                     plot_tracker(
                         writer,
                         model,
@@ -264,7 +264,7 @@ def train(
 
                 if config.folder:
                     if (
-                        config.checkpoint_every != 0
+                        config.checkpoint_every >= 0
                         and iteration % config.checkpoint_every == 0
                         and not config.checkpoint_best_only
                     ):

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -5,12 +5,10 @@ import math
 from logging import getLogger
 from typing import Callable, Union
 
-from rich.progress import (BarColumn, Progress, TaskProgressColumn, TextColumn,
-                           TimeRemainingColumn)
-from torch import complex128
+from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeRemainingColumn
+from torch import complex128, float32, float64
 from torch import device as torch_device
 from torch import dtype as torch_dtype
-from torch import float32, float64
 from torch.nn import DataParallel, Module
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
@@ -19,9 +17,13 @@ from torch.utils.tensorboard import SummaryWriter
 from qadence.ml_tools.config import TrainConfig
 from qadence.ml_tools.data import DictDataLoader, data_to_device
 from qadence.ml_tools.optimize_step import optimize_step
-from qadence.ml_tools.printing import (log_model_tracker, log_tracker,
-                                       plot_tracker, print_metrics,
-                                       write_tracker)
+from qadence.ml_tools.printing import (
+    log_model_tracker,
+    log_tracker,
+    plot_tracker,
+    print_metrics,
+    write_tracker,
+)
 from qadence.ml_tools.saveload import load_checkpoint, write_checkpoint
 from qadence.types import ExperimentTrackingTool
 

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -264,7 +264,7 @@ def train(
 
                 if config.folder:
                     if (
-                        config.checkpoint_every >= 0
+                        config.checkpoint_every > 0
                         and iteration % config.checkpoint_every == 0
                         and not config.checkpoint_best_only
                     ):

--- a/qadence/ml_tools/train_no_grad.py
+++ b/qadence/ml_tools/train_no_grad.py
@@ -6,8 +6,7 @@ from typing import Callable
 
 import nevergrad as ng
 from nevergrad.optimization.base import Optimizer as NGOptimizer
-from rich.progress import (BarColumn, Progress, TaskProgressColumn, TextColumn,
-                           TimeRemainingColumn)
+from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeRemainingColumn
 from torch import Tensor
 from torch.nn import Module
 from torch.utils.data import DataLoader
@@ -16,9 +15,13 @@ from torch.utils.tensorboard import SummaryWriter
 from qadence.ml_tools.config import TrainConfig
 from qadence.ml_tools.data import DictDataLoader
 from qadence.ml_tools.parameters import get_parameters, set_parameters
-from qadence.ml_tools.printing import (log_model_tracker, log_tracker,
-                                       plot_tracker, print_metrics,
-                                       write_tracker)
+from qadence.ml_tools.printing import (
+    log_model_tracker,
+    log_tracker,
+    plot_tracker,
+    print_metrics,
+    write_tracker,
+)
 from qadence.ml_tools.saveload import load_checkpoint, write_checkpoint
 from qadence.ml_tools.tensors import promote_to_tensor
 from qadence.types import ExperimentTrackingTool
@@ -111,7 +114,7 @@ def train(
             if config.write_every != 0 and iteration % config.write_every == 0:
                 write_tracker(writer, loss, metrics, iteration, tracking_tool=config.tracking_tool)
 
-            if config.plot_every !=0 and iteration % config.plot_every == 0:
+            if config.plot_every != 0 and iteration % config.plot_every == 0:
                 plot_tracker(
                     writer,
                     model,

--- a/qadence/ml_tools/train_no_grad.py
+++ b/qadence/ml_tools/train_no_grad.py
@@ -6,13 +6,8 @@ from typing import Callable
 
 import nevergrad as ng
 from nevergrad.optimization.base import Optimizer as NGOptimizer
-from rich.progress import (
-    BarColumn,
-    Progress,
-    TaskProgressColumn,
-    TextColumn,
-    TimeRemainingColumn,
-)
+from rich.progress import (BarColumn, Progress, TaskProgressColumn, TextColumn,
+                           TimeRemainingColumn)
 from torch import Tensor
 from torch.nn import Module
 from torch.utils.data import DataLoader
@@ -21,13 +16,9 @@ from torch.utils.tensorboard import SummaryWriter
 from qadence.ml_tools.config import TrainConfig
 from qadence.ml_tools.data import DictDataLoader
 from qadence.ml_tools.parameters import get_parameters, set_parameters
-from qadence.ml_tools.printing import (
-    log_model_tracker,
-    log_tracker,
-    plot_tracker,
-    print_metrics,
-    write_tracker,
-)
+from qadence.ml_tools.printing import (log_model_tracker, log_tracker,
+                                       plot_tracker, print_metrics,
+                                       write_tracker)
 from qadence.ml_tools.saveload import load_checkpoint, write_checkpoint
 from qadence.ml_tools.tensors import promote_to_tensor
 from qadence.types import ExperimentTrackingTool
@@ -114,13 +105,13 @@ def train(
             else:
                 raise NotImplementedError("Unsupported dataloader type!")
 
-            if iteration % config.print_every == 0 and config.verbose:
+            if config.print_every != 0 and iteration % config.print_every == 0 and config.verbose:
                 print_metrics(loss, metrics, iteration)
 
-            if iteration % config.write_every == 0:
+            if config.write_every != 0 and iteration % config.write_every == 0:
                 write_tracker(writer, loss, metrics, iteration, tracking_tool=config.tracking_tool)
 
-            if iteration % config.plot_every == 0:
+            if config.plot_every !=0 and iteration % config.plot_every == 0:
                 plot_tracker(
                     writer,
                     model,

--- a/qadence/ml_tools/train_no_grad.py
+++ b/qadence/ml_tools/train_no_grad.py
@@ -124,7 +124,7 @@ def train(
                 )
 
             if config.folder:
-                if iteration % config.checkpoint_every == 0:
+                if config.checkpoint_every > 0 and iteration % config.checkpoint_every == 0:
                     write_checkpoint(config.folder, model, optimizer, iteration)
 
             if iteration >= init_iter + config.max_iter:

--- a/qadence/ml_tools/train_no_grad.py
+++ b/qadence/ml_tools/train_no_grad.py
@@ -108,13 +108,13 @@ def train(
             else:
                 raise NotImplementedError("Unsupported dataloader type!")
 
-            if config.print_every != 0 and iteration % config.print_every == 0 and config.verbose:
+            if config.print_every > 0 and iteration % config.print_every == 0 and config.verbose:
                 print_metrics(loss, metrics, iteration)
 
-            if config.write_every != 0 and iteration % config.write_every == 0:
+            if config.write_every > 0 and iteration % config.write_every == 0:
                 write_tracker(writer, loss, metrics, iteration, tracking_tool=config.tracking_tool)
 
-            if config.plot_every != 0 and iteration % config.plot_every == 0:
+            if config.plot_every > 0 and iteration % config.plot_every == 0:
                 plot_tracker(
                     writer,
                     model,


### PR DESCRIPTION
This can be desired behavior in some cases, and is perhaps a better behaviour than the current where we end up raising DivideByZero errors.


We can perhaps use the `__post_int__` of the `TrainConfig` to do more validation here (like negative values), and print a warning?

Not sure what we think is best.