### PR TITLE
[Feature] Add in-place loading method to QuantumModel

### DIFF
--- a/qadence/ml_tools/saveload.py
+++ b/qadence/ml_tools/saveload.py
@@ -72,7 +72,8 @@ def write_checkpoint(
     device = None
     try:
         # We extract the device from the pyqtorch native circuit
-        device = str(model.device).split(":")[0]  # in case of using several CUDA devices
+        device = model.device if isinstance(QuantumModel, QNN) else next(model.parameters()).device
+        device = str(device).split(":")[0]  # in case of using several CUDA devices
     except Exception as e:
         msg = (
             f"Unable to identify in which device the QuantumModel is stored due to {e}."
@@ -132,7 +133,7 @@ def load_model(
     try:
         iteration, model_dict = torch.load(folder / model_ckpt_name, *args, **kwargs)
         if isinstance(model, (QuantumModel, QNN)):
-            model._from_dict(model_dict, as_torch=True)
+            model.load_params_from_dict(model_dict)
         elif isinstance(model, Module):
             model.load_state_dict(model_dict, strict=True)
         # Load model to a specific gpu device if specified

--- a/qadence/model.py
+++ b/qadence/model.py
@@ -447,14 +447,13 @@ class QuantumModel(nn.Module):
         """
         param_dict = d["param_dict"]
         for n, param in param_dict.items():
-            if n in param_dict:
-                try:
-                    with torch.no_grad():
-                        self._params[n].copy_(
-                            torch.nn.Parameter(param, requires_grad=param.requires_grad)
-                        )
-                except Exception as e:
-                    logger.warning(f"Unable to load parameter {n} from dictionary due to {e}.")
+            try:
+                with torch.no_grad():
+                    self._params[n].copy_(
+                        torch.nn.Parameter(param, requires_grad=param.requires_grad)
+                    )
+            except Exception as e:
+                logger.warning(f"Unable to load parameter {n} from dictionary due to {e}.")
 
     def save(
         self, folder: str | Path, file_name: str = "quantum_model.pt", save_params: bool = True

--- a/tests/qadence/test_quantum_model.py
+++ b/tests/qadence/test_quantum_model.py
@@ -14,6 +14,7 @@ from qadence.blocks import AbstractBlock, chain, kron
 from qadence.circuit import QuantumCircuit
 from qadence.constructors import hea, total_magnetization
 from qadence.divergences import js_divergence
+from qadence.ml_tools import set_parameters, get_parameters
 from qadence.ml_tools.utils import rand_featureparameters
 from qadence.model import QuantumModel
 from qadence.operations import MCRX, RX, HamEvo, I, Toffoli, X, Z
@@ -173,6 +174,25 @@ def test_save_load_qm_pyq(BasicQuantumModel: QuantumModel, tmp_path: Path) -> No
         ser_exp = ser_qm.expectation({})
         assert torch.allclose(ser_exp, pyq_expectation_orig)
         assert torch.allclose(pyq_expectation_orig, pyq_expectation_loaded)
+
+
+def test_load_params_from_dict(BasicQuantumModel: QuantumModel) -> None:
+    model = BasicQuantumModel
+    ev0 = model.expectation({})[0]
+    d = model._to_dict(save_params=True)
+    model.load_params_from_dict(d, strict=True)
+    ev1 = model.expectation({})[0]
+    assert torch.allclose(ev0, ev1)
+
+    # Check that an error is thrown if the dict does not match
+    # the model parameters when strict=True
+    d["param_dict"]["new_dummy_parameter"] = VariationalParameter("new_dummy_parameter")
+    with pytest.raises(RuntimeError):
+        model.load_params_from_dict(d, strict=True)
+
+    # If strict=False, it should not throw an exception
+    model.load_params_from_dict(d, strict=False)
+    assert not torch.all(torch.isnan(model.expectation({})))
 
 
 def test_hamevo_qm() -> None:

--- a/tests/qadence/test_quantum_model.py
+++ b/tests/qadence/test_quantum_model.py
@@ -14,7 +14,6 @@ from qadence.blocks import AbstractBlock, chain, kron
 from qadence.circuit import QuantumCircuit
 from qadence.constructors import hea, total_magnetization
 from qadence.divergences import js_divergence
-from qadence.ml_tools import set_parameters, get_parameters
 from qadence.ml_tools.utils import rand_featureparameters
 from qadence.model import QuantumModel
 from qadence.operations import MCRX, RX, HamEvo, I, Toffoli, X, Z


### PR DESCRIPTION
Fixes #484 

This PR proposes a new method in QuantumModel, `load_params_from_dict()` which allows to load the parameters from a dictionary directly to the current model. There is already a similar method `.from_dict()` but that one is a class method that initializes a new instance from the configuration saved in the state dictionary. Adding `load_params_from_dict()` fixes the bug mentioned in #484 as it allows to load the parameters from the dict 'in-place' without initializing a new instance. This is especially important in case the optimizer is defined before loading a checkpoint (as in the qadence's `train()` function) otherwise the optimizer will point to the old model and the parameters of the newly instantiated model won't be updated.

Aside from this, I also reworked the tests so that we properly test loading and saving ckpts. The main contribution here is that now the models are always modified after being saved, so that when they are loaded again the tests won't pass if the loading is not successful (this was not the case before).

Lastly, I also modified the line below so that it also works with torch modules with no `.device()` method. This assumes that all parameters in the module are saved in the same device but I think it's a pretty safe guess
 https://github.com/pasqal-io/qadence/blob/d478f8a7d9c2b3dd1f011099beb2c00af23fe20f/qadence/ml_tools/saveload.py#L75