### PR TITLE
[Feature] Adding callback functionalities in train functions

### DIFF
--- a/docs/tutorials/qml/ml_tools.md
+++ b/docs/tutorials/qml/ml_tools.md
@@ -88,7 +88,7 @@ from qadence.ml_tools import TrainConfig, Callback
 batch_size = 5
 n_epochs = 100
 
-custom_callback = Callback(lambda opt_res: print(opt_res.model.parameters()) if opt_res.loss < 1.0e-03 else print('Loss threshold not yet reached.'), every=10, call_end_epoch=True)
+custom_callback = Callback(lambda opt_res: print(opt_res.model.parameters()), callback_condition=lambda opt_res: opt_res.loss < 1.0e-03, called_every=10, call_end_epoch=True)
 
 config = TrainConfig(
     folder="some_path/",

--- a/docs/tutorials/qml/ml_tools.md
+++ b/docs/tutorials/qml/ml_tools.md
@@ -78,12 +78,17 @@ def loss_fn(model: torch.nn.Module, data: torch.Tensor) -> tuple[torch.Tensor, d
 
 The [`TrainConfig`][qadence.ml_tools.config.TrainConfig] tells `train_with_grad` what batch_size should be used,
 how many epochs to train, in which intervals to print/log metrics and how often to store intermediate checkpoints.
+It is also possible to provide custom callback functions by instantiating a [`Callback`][qadence.ml_tools.config.Callback]
+with a function `callback` that only accept as argument an instance of [`OptimizeResult`][qadence.ml_tools.data.OptimizeResult] created within the `train` functions.
+One can also provide a `callback_condition` function, also only accepting an instance of [`OptimizeResult`][qadence.ml_tools.data.OptimizeResult], which returns True if `callback` should be called. If no `callback_condition` is provided, `callback` is called at every x epochs (specified by `Callback`'s `every` argument). We can also specify in which part of the training function the `Callback` will be applied.
 
 ```python exec="on" source="material-block"
-from qadence.ml_tools import TrainConfig
+from qadence.ml_tools import TrainConfig, Callback
 
 batch_size = 5
 n_epochs = 100
+
+custom_callback = Callback(lambda opt_res: print(opt_res.model.parameters()) if opt_res.loss < 1.0e-03 else print('Loss threshold not yet reached.'), every=10, call_end_epoch=True)
 
 config = TrainConfig(
     folder="some_path/",
@@ -91,6 +96,7 @@ config = TrainConfig(
     checkpoint_every=100,
     write_every=100,
     batch_size=batch_size,
+    callbacks = [custom_callback]
 )
 ```
 

--- a/docs/tutorials/qml/ml_tools.md
+++ b/docs/tutorials/qml/ml_tools.md
@@ -80,7 +80,7 @@ The [`TrainConfig`][qadence.ml_tools.config.TrainConfig] tells `train_with_grad`
 how many epochs to train, in which intervals to print/log metrics and how often to store intermediate checkpoints.
 It is also possible to provide custom callback functions by instantiating a [`Callback`][qadence.ml_tools.config.Callback]
 with a function `callback` that only accept as argument an instance of [`OptimizeResult`][qadence.ml_tools.data.OptimizeResult] created within the `train` functions.
-One can also provide a `callback_condition` function, also only accepting an instance of [`OptimizeResult`][qadence.ml_tools.data.OptimizeResult], which returns True if `callback` should be called. If no `callback_condition` is provided, `callback` is called at every x epochs (specified by `Callback`'s `every` argument). We can also specify in which part of the training function the `Callback` will be applied.
+One can also provide a `callback_condition` function, also only accepting an instance of [`OptimizeResult`][qadence.ml_tools.data.OptimizeResult], which returns True if `callback` should be called. If no `callback_condition` is provided, `callback` is called at every x epochs (specified by `Callback`'s `called_every` argument). We can also specify in which part of the training function the `Callback` will be applied.
 
 ```python exec="on" source="material-block"
 from qadence.ml_tools import TrainConfig, Callback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 license = { text = "Apache 2.0" }
-version = "1.7.4"
+version = "1.7.5"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ filterwarnings = [
 [tool.hatch.envs.docs]
 dependencies = [
     "mkdocs",
+    "mkdocs_autorefs<1.1.0",
     "mkdocs-material",
     "mkdocstrings",
     "mkdocstrings-python",

--- a/qadence/ml_tools/__init__.py
+++ b/qadence/ml_tools/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .config import AnsatzConfig, FeatureMapConfig, TrainConfig
+from .config import AnsatzConfig, Callback, FeatureMapConfig, TrainConfig
 from .constructors import create_ansatz, create_fm_blocks, observable_from_config
 from .data import DictDataLoader, InfiniteTensorDataset, to_dataloader
 from .models import QNN
@@ -23,6 +23,7 @@ __all__ = [
     "observable_from_config",
     "QNN",
     "TrainConfig",
+    "Callback",
     "train_with_grad",
     "train_gradient_free",
     "write_checkpoint",

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -44,6 +44,8 @@ class Callback:
             If callback_condition is None, we set
             callback_condition to returns True when iteration % every == 0
         call_before_opt (bool): If true, callback is done before training.
+        call_end_epoch (bool): If true, callback is done during training,
+        after an epoch is performed.
         call_after_opt (bool): If true, callback is done after training.
     """
 
@@ -53,10 +55,12 @@ class Callback:
         callback_condition: Callable[..., bool] | None = None,
         every: int = 1,
         call_before_opt: bool = False,
+        call_end_epoch: bool = True,
         call_after_opt: bool = True,
     ) -> None:
         self.callback = callback
         self.call_before_opt = call_before_opt
+        self.call_end_epoch = call_end_epoch
         self.call_after_opt = call_after_opt
         self.every = every
 

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -28,6 +28,9 @@ from qadence.types import (
 
 logger = getLogger(__file__)
 
+CallbackFunction = Callable[[OptimizeResult], None]
+CallbackConditionFunction = Callable[[OptimizeResult], bool]
+
 
 class Callback:
     """Callback functions are calling in train functions.
@@ -36,10 +39,10 @@ class Callback:
     an OptimizeResult instance.
 
     Attributes:
-        callback (Callable[..., None]): Callback function accepting an
+        callback (CallbackFunction): Callback function accepting an
             OptimizeResult as first argument.
-        callback_condition (Callable[..., bool] | None, optional): Function that conditions the
-            call to callback. Defaults to None.
+        callback_condition (CallbackConditionFunction | None, optional): Function that
+            conditions the call to callback. Defaults to None.
         every (int, optional): Callback to be called each `every` epoch. Defaults to 1.
             If callback_condition is None, we set
             callback_condition to returns True when iteration % every == 0.
@@ -55,8 +58,8 @@ class Callback:
 
     def __init__(
         self,
-        callback: Callable[..., None],
-        callback_condition: Callable[..., bool] | None = None,
+        callback: CallbackFunction,
+        callback_condition: CallbackConditionFunction | None = None,
         every: int = 1,
         call_before_opt: bool = False,
         call_end_epoch: bool = True,
@@ -66,10 +69,10 @@ class Callback:
         """Initialized Callback.
 
         Args:
-            callback (Callable[..., None]): Callback function accepting an
+            callback (CallbackFunction): Callback function accepting an
                 OptimizeResult as ifrst argument.
-            callback_condition (Callable[..., bool] | None, optional): Function that conditions the
-                call to callback. Defaults to None.
+            callback_condition (CallbackConditionFunction | None, optional): Function that
+                conditions the call to callback. Defaults to None.
             every (int, optional): Callback to be called each `every` epoch. Defaults to 1.
                 If callback_condition is None, we set
                 callback_condition to returns True when iteration % every == 0.

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -38,16 +38,19 @@ class Callback:
     Attributes:
         callback (Callable[..., None]): Callback function accepting an
             OptimizeResult as ifrst argument.
-        callback_condition (Callable[..., None] | None): Function that condition the
-            call to callback.
-        every (int): Callback to be called each `every` epoch.
+        callback_condition (Callable[..., bool] | None, optional): Function that conditions the
+            call to callback. Defaults to None.
+        every (int, optional): Callback to be called each `every` epoch. Defaults to 1.
             If callback_condition is None, we set
-            callback_condition to returns True when iteration % every == 0
-        call_before_opt (bool): If true, callback is applied before training.
-        call_end_epoch (bool): If true, callback is applied during training,
-        after an epoch is performed.
-        call_after_opt (bool): If true, callback is applied after training.
-        call_during_eval (bool): If true, callback is applied during evaluation.
+            callback_condition to returns True when iteration % every == 0.
+        call_before_opt (bool, optional): If true, callback is applied before training.
+            Defaults to False.
+        call_end_epoch (bool, optional): If true, callback is applied during training,
+            after an epoch is performed. Defaults to True.
+        call_after_opt (bool, optional): If true, callback is applied after training.
+            Defaults to False.
+        call_during_eval (bool, optional): If true, callback is applied during evaluation.
+            Defaults to False.
     """
 
     def __init__(
@@ -60,6 +63,25 @@ class Callback:
         call_after_opt: bool = False,
         call_during_eval: bool = False,
     ) -> None:
+        """Initialized Callback.
+
+        Args:
+            callback (Callable[..., None]): Callback function accepting an
+                OptimizeResult as ifrst argument.
+            callback_condition (Callable[..., bool] | None, optional): Function that conditions the
+                call to callback. Defaults to None.
+            every (int, optional): Callback to be called each `every` epoch. Defaults to 1.
+                If callback_condition is None, we set
+                callback_condition to returns True when iteration % every == 0.
+            call_before_opt (bool, optional): If true, callback is applied before training.
+                Defaults to False.
+            call_end_epoch (bool, optional): If true, callback is applied during training,
+                after an epoch is performed. Defaults to True.
+            call_after_opt (bool, optional): If true, callback is applied after training.
+                Defaults to False.
+            call_during_eval (bool, optional): If true, callback is applied during evaluation.
+                Defaults to False.
+        """
         self.callback = callback
         self.call_before_opt = call_before_opt
         self.call_end_epoch = call_end_epoch

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -98,9 +98,9 @@ class Callback:
         else:
             self.callback_condition = callback_condition
 
-    def __call__(self, opt_result: OptimizeResult, *args: Any, **kwargs: Any) -> Any:
+    def __call__(self, opt_result: OptimizeResult) -> Any:
         if self.callback_condition(opt_result):
-            return self.callback(opt_result, *args, **kwargs)
+            return self.callback(opt_result)
 
 
 @dataclass

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -44,8 +44,6 @@ class Callback:
             If callback_condition is None, we set
             callback_condition to returns True when iteration % every == 0
         call_before_opt (bool): If true, callback is done before training.
-            Note, this means this applies only on the validation data as
-            we only perform validation before training.
     """
 
     def __init__(

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -37,7 +37,7 @@ class Callback:
 
     Attributes:
         callback (Callable[..., None]): Callback function accepting an
-            OptimizeResult as ifrst argument.
+            OptimizeResult as first argument.
         callback_condition (Callable[..., bool] | None, optional): Function that conditions the
             call to callback. Defaults to None.
         every (int, optional): Callback to be called each `every` epoch. Defaults to 1.

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -30,7 +30,7 @@ logger = getLogger(__file__)
 
 
 class Callback:
-    """Callback functions are calling during training.
+    """Callback functions are calling in train functions.
 
     Each callback function should take at least as first input
     an OptimizeResult instance.
@@ -43,10 +43,11 @@ class Callback:
         every (int): Callback to be called each `every` epoch.
             If callback_condition is None, we set
             callback_condition to returns True when iteration % every == 0
-        call_before_opt (bool): If true, callback is done before training.
-        call_end_epoch (bool): If true, callback is done during training,
+        call_before_opt (bool): If true, callback is applied before training.
+        call_end_epoch (bool): If true, callback is applied during training,
         after an epoch is performed.
-        call_after_opt (bool): If true, callback is done after training.
+        call_after_opt (bool): If true, callback is applied after training.
+        call_during_eval (bool): If true, callback is applied during evaluation.
     """
 
     def __init__(
@@ -56,12 +57,15 @@ class Callback:
         every: int = 1,
         call_before_opt: bool = False,
         call_end_epoch: bool = True,
-        call_after_opt: bool = True,
+        call_after_opt: bool = False,
+        call_during_eval: bool = False,
     ) -> None:
         self.callback = callback
         self.call_before_opt = call_before_opt
         self.call_end_epoch = call_end_epoch
         self.call_after_opt = call_after_opt
+        self.call_during_eval = call_during_eval
+
         self.every = every
 
         if callback_condition is None:

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -13,7 +13,7 @@ from torch import Tensor
 
 from qadence.blocks.analog import AnalogBlock
 from qadence.blocks.primitive import ParametricBlock
-from qadence.ml_tools.utils import OptimizeResult
+from qadence.ml_tools.data import OptimizeResult
 from qadence.operations import RX, AnalogRX
 from qadence.parameters import Parameter
 from qadence.types import (
@@ -44,6 +44,8 @@ class Callback:
             If callback_condition is None, we set
             callback_condition to returns True when iteration % every == 0
         call_before_opt (bool): If true, callback is done before training.
+            Note, this means this applies only on the validation data as
+            we only perform validation before training.
     """
 
     def __init__(

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -93,6 +93,8 @@ class Callback:
         self.call_after_opt = call_after_opt
         self.call_during_eval = call_during_eval
 
+        if called_every <= 0:
+            raise ValueError("Please provide a strictly positive `called_every` argument.")
         self.called_every = called_every
 
         if callback_condition is None:
@@ -101,11 +103,7 @@ class Callback:
             self.callback_condition = callback_condition
 
     def __call__(self, opt_result: OptimizeResult) -> Any:
-        if (
-            (self.called_every > 0)
-            and opt_result.iteration % self.called_every == 0
-            and self.callback_condition(opt_result)
-        ):
+        if opt_result.iteration % self.called_every == 0 and self.callback_condition(opt_result):
             return self.callback(opt_result)
 
 

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -39,8 +39,8 @@ class OptimizeResult:
 
     iteration: int
     model: Module
-    data: Tensor | None
-    loss: Tensor | None
+    data: dict | list | Tensor | None
+    loss: Tensor | float
 
     metrics: dict
 
@@ -59,6 +59,7 @@ class Callback:
         every (int): Callback to be called each `every` epoch.
             If callback_condition is None, we set
             callback_condition to returns True when iteration % every == 0
+        call_before_opt (bool): If true, callback is done before training.
     """
 
     def __init__(
@@ -66,9 +67,10 @@ class Callback:
         callback: Callable[..., None],
         callback_condition: Callable[..., bool] | None = None,
         every: int = 1,
+        call_before_opt: bool = False,
     ) -> None:
         self.callback = callback
-
+        self.call_before_opt = call_before_opt
         self.every = every
 
         if callback_condition is None:

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -10,10 +10,10 @@ from uuid import uuid4
 
 from sympy import Basic
 from torch import Tensor
-from torch.nn import Module
 
 from qadence.blocks.analog import AnalogBlock
 from qadence.blocks.primitive import ParametricBlock
+from qadence.ml_tools.utils import OptimizeResult
 from qadence.operations import RX, AnalogRX
 from qadence.parameters import Parameter
 from qadence.types import (
@@ -27,22 +27,6 @@ from qadence.types import (
 )
 
 logger = getLogger(__file__)
-
-
-@dataclass
-class OptimizeResult:
-    """OptimizeResult stores many optimization.
-
-    intermediate values at a current iteration,
-    such as model, loss values and data.
-    """
-
-    iteration: int
-    model: Module
-    data: dict | list | Tensor | None
-    loss: Tensor | float
-
-    metrics: dict
 
 
 class Callback:

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -94,15 +94,12 @@ class Callback:
         self.every = every
 
         if callback_condition is None:
-            if self.every > 1:
-                self.callback_condition = lambda opt_result: opt_result.iteration % self.every == 0
-            else:
-                self.callback_condition = lambda opt_result: True
+            self.callback_condition = lambda opt_result: True
         else:
             self.callback_condition = callback_condition
 
     def __call__(self, opt_result: OptimizeResult) -> Any:
-        if self.callback_condition(opt_result):
+        if opt_result.iteration % self.every == 0 and self.callback_condition(opt_result):
             return self.callback(opt_result)
 
 

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -44,6 +44,7 @@ class Callback:
             If callback_condition is None, we set
             callback_condition to returns True when iteration % every == 0
         call_before_opt (bool): If true, callback is done before training.
+        call_after_opt (bool): If true, callback is done after training.
     """
 
     def __init__(
@@ -52,9 +53,11 @@ class Callback:
         callback_condition: Callable[..., bool] | None = None,
         every: int = 1,
         call_before_opt: bool = False,
+        call_after_opt: bool = True,
     ) -> None:
         self.callback = callback
         self.call_before_opt = call_before_opt
+        self.call_after_opt = call_after_opt
         self.every = every
 
         if callback_condition is None:

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -43,7 +43,8 @@ class Callback:
             OptimizeResult as first argument.
         callback_condition (CallbackConditionFunction | None, optional): Function that
             conditions the call to callback. Defaults to None.
-        every (int, optional): Callback to be called each `every` epoch. Defaults to 1.
+        called_every (int, optional): Callback to be called each `called_every` epoch.
+            Defaults to 1.
             If callback_condition is None, we set
             callback_condition to returns True when iteration % every == 0.
         call_before_opt (bool, optional): If true, callback is applied before training.
@@ -60,7 +61,7 @@ class Callback:
         self,
         callback: CallbackFunction,
         callback_condition: CallbackConditionFunction | None = None,
-        every: int = 1,
+        called_every: int = 1,
         call_before_opt: bool = False,
         call_end_epoch: bool = True,
         call_after_opt: bool = False,
@@ -73,7 +74,8 @@ class Callback:
                 OptimizeResult as ifrst argument.
             callback_condition (CallbackConditionFunction | None, optional): Function that
                 conditions the call to callback. Defaults to None.
-            every (int, optional): Callback to be called each `every` epoch. Defaults to 1.
+            called_every (int, optional): Callback to be called each `called_every` epoch.
+                Defaults to 1.
                 If callback_condition is None, we set
                 callback_condition to returns True when iteration % every == 0.
             call_before_opt (bool, optional): If true, callback is applied before training.
@@ -91,7 +93,7 @@ class Callback:
         self.call_after_opt = call_after_opt
         self.call_during_eval = call_during_eval
 
-        self.every = every
+        self.called_every = called_every
 
         if callback_condition is None:
             self.callback_condition = lambda opt_result: True
@@ -99,7 +101,11 @@ class Callback:
             self.callback_condition = callback_condition
 
     def __call__(self, opt_result: OptimizeResult) -> Any:
-        if opt_result.iteration % self.every == 0 and self.callback_condition(opt_result):
+        if (
+            (self.called_every > 0)
+            and opt_result.iteration % self.called_every == 0
+            and self.callback_condition(opt_result)
+        ):
             return self.callback(opt_result)
 
 

--- a/qadence/ml_tools/data.py
+++ b/qadence/ml_tools/data.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import singledispatch
 from itertools import cycle
 from typing import Any, Iterator
@@ -17,15 +17,23 @@ from torch.utils.data import DataLoader, IterableDataset, TensorDataset
 class OptimizeResult:
     """OptimizeResult stores many optimization intermediate values.
 
-    We store at a  current iteration,
-    the model, loss values and data.
+    We store at a current iteration,
+    the model, optimizer, loss values, metrics. An extra dict
+    can be used for saving other information to be used for callbacks.
     """
 
     iteration: int
+    """Current iteration number."""
     model: Module
+    """Model at iteration."""
     optimizer: Optimizer | NGOptimizer
+    """Optimizer at iteration."""
     loss: Tensor | float | None
-    metrics: dict
+    """Loss value."""
+    metrics: dict = field(default_factory=lambda: dict())
+    """Metrics that can be saved during training."""
+    extra: dict = field(default_factory=lambda: dict())
+    """Extra dict for saving anything else to be used in callbacks."""
 
 
 @dataclass

--- a/qadence/ml_tools/data.py
+++ b/qadence/ml_tools/data.py
@@ -5,9 +5,28 @@ from functools import singledispatch
 from itertools import cycle
 from typing import Any, Iterator
 
+from nevergrad.optimization.base import Optimizer as NGOptimizer
 from torch import Tensor
 from torch import device as torch_device
+from torch.nn import Module
+from torch.optim import Optimizer
 from torch.utils.data import DataLoader, IterableDataset, TensorDataset
+
+
+@dataclass
+class OptimizeResult:
+    """OptimizeResult stores many optimization intermediate values.
+
+    We store at a  current iteration,
+    the model, loss values and data.
+    """
+
+    iteration: int
+    model: Module
+    optimizer: Optimizer | NGOptimizer
+    loss: Tensor | float
+
+    metrics: dict
 
 
 @dataclass

--- a/qadence/ml_tools/data.py
+++ b/qadence/ml_tools/data.py
@@ -28,7 +28,7 @@ class OptimizeResult:
     """Model at iteration."""
     optimizer: Optimizer | NGOptimizer
     """Optimizer at iteration."""
-    loss: Tensor | float | None
+    loss: Tensor | float | None = None
     """Loss value."""
     metrics: dict = field(default_factory=lambda: dict())
     """Metrics that can be saved during training."""

--- a/qadence/ml_tools/data.py
+++ b/qadence/ml_tools/data.py
@@ -24,8 +24,7 @@ class OptimizeResult:
     iteration: int
     model: Module
     optimizer: Optimizer | NGOptimizer
-    loss: Tensor | float
-
+    loss: Tensor | float | None
     metrics: dict
 
 

--- a/qadence/ml_tools/optimize_step.py
+++ b/qadence/ml_tools/optimize_step.py
@@ -29,10 +29,11 @@ def optimize_step(
         xs (dict | list | torch.Tensor | None): the input data. If None it means
             that the given model does not require any input data
         device (torch.device): A target device to run computation on.
+        dtype (torch.dtype): Data type for xs conversion.
 
     Returns:
-        tuple: tuple containing the model, the optimizer, a dictionary with
-            the collected metrics and the compute value loss
+        tuple: tuple containing the computed loss value, and a dictionary with
+            the collected metrics.
     """
 
     loss, metrics = None, {}

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -272,7 +272,7 @@ def train(
             opt_result = OptimizeResult(init_iter, model, optimizer, None, dict())
             if perform_val:
                 dl_iter_val = iter(val_dataloader) if val_dataloader is not None else None
-                best_val_loss, metrics = next_loss_iter(dl_iter_val)
+                best_val_loss, metrics, *_ = next_loss_iter(dl_iter_val)
                 metrics["val_loss"] = best_val_loss
                 opt_result.metrics = metrics
                 run_callbacks(callbacks_before_opt_eval, opt_result)

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -167,6 +167,16 @@ def train(
         )
 
     def next_loss_iter(dl_iter: Union[None, DataLoader, DictDataLoader]) -> Any:
+        """Get loss on the next batch of a dataloader.
+
+            loaded on device if not None.
+
+        Args:
+            dl_iter (Union[None, DataLoader, DictDataLoader]): Dataloader.
+
+        Returns:
+            Any: Loss value
+        """
         xs = next(dl_iter) if dl_iter is not None else None
         xs_to_device = data_to_device(xs, device=device, dtype=data_dtype)
         return loss_fn(model, xs_to_device)

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -250,6 +250,7 @@ def train(
 
         # outer epoch loop
         init_iter += 1
+        callbacks_end_epoch = [callback for callback in callbacks if callback.call_end_epoch]
         for iteration in progress.track(range(init_iter, init_iter + config.max_iter)):
             try:
                 # in case there is not data needed by the model
@@ -277,7 +278,7 @@ def train(
                     # which is printed accordingly by the previous iteration number
                     print_metrics(loss, metrics, iteration - 1)
 
-                run_callbacks(callbacks, opt_result)
+                run_callbacks(callbacks_end_epoch, opt_result)
 
                 if perform_val:
                     if iteration % config.val_every == 0:

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 import math
 from logging import getLogger
-from typing import Callable, Union
+from typing import Any, Callable, Union
 
 from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeRemainingColumn
 from torch import complex128, float32, float64
@@ -160,6 +160,18 @@ def train(
 
     best_val_loss = math.inf
 
+    # check supported dataloader
+    if dataloader and not isinstance(dataloader, (DictDataLoader, DataLoader)):
+        raise NotImplementedError(
+            f"Unsupported dataloader type: {type(dataloader)}. "
+            "You can use e.g. `qadence.ml_tools.to_dataloader` to build a dataloader."
+        )
+
+    def next_iter_loss(dl_iter: Union[None, DataLoader, DictDataLoader]) -> Any:
+        xs = next(dl_iter) if dl_iter is not None else None
+        xs_to_device = data_to_device(xs, device=device, dtype=data_dtype)
+        return loss_fn(model, xs_to_device)
+
     with progress:
         dl_iter = iter(dataloader) if dataloader is not None else None
 
@@ -167,10 +179,7 @@ def train(
         try:
             if perform_val:
                 dl_iter_val = iter(val_dataloader) if val_dataloader is not None else None
-                xs = next(dl_iter_val)
-                xs_to_device = data_to_device(xs, device=device, dtype=data_dtype)
-                best_val_loss, metrics, *_ = loss_fn(model, xs_to_device)
-
+                best_val_loss, metrics, *_ = next_iter_loss(dl_iter_val)
                 metrics["val_loss"] = best_val_loss
                 write_tracker(writer, None, metrics, init_iter, tracking_tool=config.tracking_tool)
 
@@ -194,36 +203,19 @@ def train(
         # outer epoch loop
         init_iter += 1
         for iteration in progress.track(range(init_iter, init_iter + config.max_iter)):
+            xs = None
             try:
                 # in case there is not data needed by the model
                 # this is the case, for example, of quantum models
                 # which do not have classical input data (e.g. chemistry)
-                if dataloader is None:
-                    loss, metrics = optimize_step(
-                        model=model,
-                        optimizer=optimizer,
-                        loss_fn=loss_fn,
-                        xs=None,
-                        device=device,
-                        dtype=data_dtype,
-                    )
-                    loss = loss.item()
-
-                elif isinstance(dataloader, (DictDataLoader, DataLoader)):
-                    loss, metrics = optimize_step(
-                        model=model,
-                        optimizer=optimizer,
-                        loss_fn=loss_fn,
-                        xs=next(dl_iter),  # type: ignore[arg-type]
-                        device=device,
-                        dtype=data_dtype,
-                    )
-
-                else:
-                    raise NotImplementedError(
-                        f"Unsupported dataloader type: {type(dataloader)}. "
-                        "You can use e.g. `qadence.ml_tools.to_dataloader` to build a dataloader."
-                    )
+                loss, metrics = optimize_step(
+                    model=model,
+                    optimizer=optimizer,
+                    loss_fn=loss_fn,
+                    xs=next(dl_iter) if dataloader else None,  # type: ignore[arg-type]
+                    device=device,
+                    dtype=data_dtype,
+                )
 
                 if (
                     config.print_every > 0
@@ -250,9 +242,8 @@ def train(
                     )
                 if perform_val:
                     if iteration % config.val_every == 0:
-                        xs = next(dl_iter_val)
-                        xs_to_device = data_to_device(xs, device=device, dtype=data_dtype)
-                        val_loss, *_ = loss_fn(model, xs_to_device)
+                        val_loss, *_ = next_iter_loss(dl_iter_val)
+
                         if config.validation_criterion(val_loss, best_val_loss, config.val_epsilon):  # type: ignore[misc]
                             best_val_loss = val_loss
                             if config.folder and config.checkpoint_best_only:

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -253,7 +253,8 @@ def train(
         ]
 
     def run_callbacks(callback_iterable: list[Callback], opt_res: OptimizeResult) -> None:
-        [callback(opt_res) for callback in callback_iterable]
+        for callback in callback_iterable:
+            callback(opt_res)
 
     callbacks_before_opt = [
         callback

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -169,7 +169,7 @@ def train(
                 dl_iter_val = iter(val_dataloader) if val_dataloader is not None else None
                 xs = next(dl_iter_val)
                 xs_to_device = data_to_device(xs, device=device, dtype=data_dtype)
-                best_val_loss, metrics = loss_fn(model, xs_to_device)
+                best_val_loss, metrics, *_ = loss_fn(model, xs_to_device)
 
                 metrics["val_loss"] = best_val_loss
                 write_tracker(writer, None, metrics, init_iter, tracking_tool=config.tracking_tool)

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -270,7 +270,7 @@ def train(
 
         # Initial validation evaluation
         try:
-            opt_result = OptimizeResult(init_iter, model, optimizer, None, dict())
+            opt_result = OptimizeResult(init_iter, model, optimizer)
             if perform_val:
                 dl_iter_val = iter(val_dataloader) if val_dataloader is not None else None
                 best_val_loss, metrics, *_ = next_loss_iter(dl_iter_val)

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -193,7 +193,7 @@ def train(
         callbacks += [
             Callback(
                 lambda opt_res: print_metrics(opt_res.loss, opt_res.metrics, opt_res.iteration - 1),
-                every=config.print_every,
+                called_every=config.print_every,
                 call_after_opt=True,
             )
         ]
@@ -208,7 +208,7 @@ def train(
                 config.plotting_functions,
                 tracking_tool=config.tracking_tool,
             ),
-            every=config.plot_every,
+            called_every=config.plot_every,
             call_before_opt=True,
         )
     ]
@@ -223,7 +223,7 @@ def train(
                 opt_res.iteration,
                 tracking_tool=config.tracking_tool,
             ),
-            every=config.write_every,
+            called_every=config.write_every,
             call_before_opt=False,
             call_after_opt=True,
             call_during_eval=True,
@@ -240,7 +240,7 @@ def train(
                     opt_res.optimizer,
                     opt_res.iteration,
                 ),
-                every=config.checkpoint_every,
+                called_every=config.checkpoint_every,
                 call_before_opt=False,
                 call_after_opt=True,
             )
@@ -255,7 +255,7 @@ def train(
                     opt_res.optimizer,
                     "best",
                 ),
-                every=config.checkpoint_every,
+                called_every=config.checkpoint_every,
                 call_before_opt=True,
                 call_after_opt=True,
                 call_during_eval=True,

--- a/qadence/ml_tools/train_no_grad.py
+++ b/qadence/ml_tools/train_no_grad.py
@@ -12,8 +12,8 @@ from torch.nn import Module
 from torch.utils.data import DataLoader
 from torch.utils.tensorboard import SummaryWriter
 
-from qadence.ml_tools.config import TrainConfig
-from qadence.ml_tools.data import DictDataLoader
+from qadence.ml_tools.config import Callback, TrainConfig
+from qadence.ml_tools.data import DictDataLoader, OptimizeResult
 from qadence.ml_tools.parameters import get_parameters, set_parameters
 from qadence.ml_tools.printing import (
     log_model_tracker,
@@ -86,6 +86,12 @@ def train(
     params = get_parameters(model).detach().numpy()
     ng_params = ng.p.Array(init=params)
 
+    if not ((dataloader is None) or isinstance(dataloader, (DictDataLoader, DataLoader))):
+        raise NotImplementedError(
+            f"Unsupported dataloader type: {type(dataloader)}. "
+            "You can use e.g. `qadence.ml_tools.to_dataloader` to build a dataloader."
+        )
+
     # serial training
     # TODO: Add a parallelization using the num_workers argument in Nevergrad
     progress = Progress(
@@ -94,38 +100,84 @@ def train(
         TaskProgressColumn(),
         TimeRemainingColumn(elapsed_when_finished=True),
     )
+
+    # populate callbacks with already available internal functions
+    # printing, writing and plotting
+    callbacks = config.callbacks
+
+    # printing
+    if config.verbose and config.print_every > 0:
+        callbacks += [
+            Callback(
+                lambda opt_res: print_metrics(opt_res.loss, opt_res.metrics, opt_res.iteration),
+                every=config.print_every,
+            )
+        ]
+
+    # writing metrics
+    if config.write_every > 0:
+        callbacks += [
+            Callback(
+                lambda opt_res: write_tracker(
+                    writer,
+                    opt_res.loss,
+                    opt_res.metrics,
+                    opt_res.iteration,
+                    tracking_tool=config.tracking_tool,
+                ),
+                every=config.write_every,
+                call_after_opt=True,
+            )
+        ]
+
+    # plot tracker
+    if config.plot_every > 0:
+        callbacks += [
+            Callback(
+                lambda opt_res: plot_tracker(
+                    writer,
+                    opt_res.model,
+                    opt_res.iteration,
+                    config.plotting_functions,
+                    tracking_tool=config.tracking_tool,
+                ),
+                every=config.plot_every,
+            )
+        ]
+
+    # checkpointing
+    if config.folder and config.checkpoint_every > 0:
+        callbacks += [
+            Callback(
+                lambda opt_res: write_checkpoint(
+                    config.folder,  # type: ignore[arg-type]
+                    opt_res.model,
+                    opt_res.optimizer,
+                    opt_res.iteration,
+                ),
+                every=config.checkpoint_every,
+                call_after_opt=True,
+            )
+        ]
+
+    def run_callbacks(callback_iterable: list[Callback], opt_res: OptimizeResult) -> None:
+        [callback(opt_res) for callback in callback_iterable]
+
+    callbacks_end_opt = [
+        callback
+        for callback in callbacks
+        if callback.call_end_epoch and not callback.call_during_eval
+    ]
+
     with progress:
         dl_iter = iter(dataloader) if dataloader is not None else None
 
         for iteration in progress.track(range(init_iter, init_iter + config.max_iter)):
-            if dataloader is None:
-                loss, metrics, ng_params = _update_parameters(None, ng_params)
-
-            elif isinstance(dataloader, (DictDataLoader, DataLoader)):
-                data = next(dl_iter)  # type: ignore[arg-type]
-                loss, metrics, ng_params = _update_parameters(data, ng_params)
-
-            else:
-                raise NotImplementedError("Unsupported dataloader type!")
-
-            if config.print_every > 0 and iteration % config.print_every == 0 and config.verbose:
-                print_metrics(loss, metrics, iteration)
-
-            if config.write_every > 0 and iteration % config.write_every == 0:
-                write_tracker(writer, loss, metrics, iteration, tracking_tool=config.tracking_tool)
-
-            if config.plot_every > 0 and iteration % config.plot_every == 0:
-                plot_tracker(
-                    writer,
-                    model,
-                    iteration,
-                    config.plotting_functions,
-                    tracking_tool=config.tracking_tool,
-                )
-
-            if config.folder:
-                if config.checkpoint_every > 0 and iteration % config.checkpoint_every == 0:
-                    write_checkpoint(config.folder, model, optimizer, iteration)
+            loss, metrics, ng_params = _update_parameters(
+                None if dataloader is None else next(dl_iter), ng_params  # type: ignore[arg-type]
+            )
+            opt_result = OptimizeResult(iteration, model, optimizer, loss, metrics)
+            run_callbacks(callbacks_end_opt, opt_result)
 
             if iteration >= init_iter + config.max_iter:
                 break
@@ -137,10 +189,9 @@ def train(
     if config.log_model:
         log_model_tracker(writer, model, dataloader, tracking_tool=config.tracking_tool)
 
-    # Final writing and checkpointing
-    if config.folder:
-        write_checkpoint(config.folder, model, optimizer, iteration)
-    write_tracker(writer, loss, metrics, iteration, tracking_tool=config.tracking_tool)
+    # Final callbacks
+    callbacks_after_opt = [callback for callback in callbacks if callback.call_after_opt]
+    run_callbacks(callbacks_after_opt, opt_result)
 
     # close tracker
     if config.tracking_tool == ExperimentTrackingTool.TENSORBOARD:

--- a/qadence/ml_tools/train_no_grad.py
+++ b/qadence/ml_tools/train_no_grad.py
@@ -110,7 +110,7 @@ def train(
         callbacks += [
             Callback(
                 lambda opt_res: print_metrics(opt_res.loss, opt_res.metrics, opt_res.iteration),
-                every=config.print_every,
+                called_every=config.print_every,
             )
         ]
 
@@ -125,7 +125,7 @@ def train(
                     opt_res.iteration,
                     tracking_tool=config.tracking_tool,
                 ),
-                every=config.write_every,
+                called_every=config.write_every,
                 call_after_opt=True,
             )
         ]
@@ -141,7 +141,7 @@ def train(
                     config.plotting_functions,
                     tracking_tool=config.tracking_tool,
                 ),
-                every=config.plot_every,
+                called_every=config.plot_every,
             )
         ]
 
@@ -155,7 +155,7 @@ def train(
                     opt_res.optimizer,
                     opt_res.iteration,
                 ),
-                every=config.checkpoint_every,
+                called_every=config.checkpoint_every,
                 call_after_opt=True,
             )
         ]

--- a/qadence/ml_tools/train_no_grad.py
+++ b/qadence/ml_tools/train_no_grad.py
@@ -161,7 +161,8 @@ def train(
         ]
 
     def run_callbacks(callback_iterable: list[Callback], opt_res: OptimizeResult) -> None:
-        [callback(opt_res) for callback in callback_iterable]
+        for callback in callback_iterable:
+            callback(opt_res)
 
     callbacks_end_opt = [
         callback

--- a/qadence/ml_tools/utils.py
+++ b/qadence/ml_tools/utils.py
@@ -1,14 +1,32 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from functools import singledispatch
 from typing import Any
 
 from torch import Tensor, rand
+from torch.nn import Module
 
 from qadence import QNN, QuantumModel
 from qadence.blocks import AbstractBlock, parameters
 from qadence.circuit import QuantumCircuit
 from qadence.parameters import Parameter, stringify
+
+
+@dataclass
+class OptimizeResult:
+    """OptimizeResult stores many optimization intermediate values.
+
+    We store at a  current iteration,
+    the model, loss values and data.
+    """
+
+    iteration: int
+    model: Module
+    data: dict | list | Tensor | None
+    loss: Tensor | float
+
+    metrics: dict
 
 
 @singledispatch

--- a/qadence/ml_tools/utils.py
+++ b/qadence/ml_tools/utils.py
@@ -1,32 +1,14 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from functools import singledispatch
 from typing import Any
 
 from torch import Tensor, rand
-from torch.nn import Module
 
 from qadence import QNN, QuantumModel
 from qadence.blocks import AbstractBlock, parameters
 from qadence.circuit import QuantumCircuit
 from qadence.parameters import Parameter, stringify
-
-
-@dataclass
-class OptimizeResult:
-    """OptimizeResult stores many optimization intermediate values.
-
-    We store at a  current iteration,
-    the model, loss values and data.
-    """
-
-    iteration: int
-    model: Module
-    data: dict | list | Tensor | None
-    loss: Tensor | float
-
-    metrics: dict
 
 
 @singledispatch


### PR DESCRIPTION
Related to a comment from #202, we can use callback functions in train functions to extend possibilities to do more during these functions and allow flexibility. Similar to scipy.optimize, we have an `OptimizeResult` class storing several optimization-related object/values.  The callback should take an `OptimizeResult` as input and apply a user-defined function.

Several booleans locate filter where the callbacks should be called within train. This also allow avoiding a few if statements for some already-defined callback-type functions (writing, checkpointing, printing, etc). 