### PR TITLE
[Bug] Fix usage of the shift prefactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 license = { text = "Apache 2.0" }
-version = "1.7.5"
+version = "1.7.6"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",

--- a/qadence/engines/torch/differentiable_expectation.py
+++ b/qadence/engines/torch/differentiable_expectation.py
@@ -231,8 +231,12 @@ class DifferentiableExpectation:
             if shift_factor == 1:
                 param_to_psr[param_id] = psr_fn(eigenvalues, **psr_args)
             else:
-                psr_args_factor = {k: v * shift_factor for k, v in psr_args.items()}
-                param_to_psr[param_id] = psr_fn(eigenvalues, **psr_args)
+                psr_args_factor = psr_args.copy()
+                if "shift_prefac" in psr_args_factor:
+                    psr_args_factor["shift_prefac"] = shift_factor * psr_args_factor["shift_prefac"]
+                else:
+                    psr_args_factor["shift_prefac"] = shift_factor
+                param_to_psr[param_id] = psr_fn(eigenvalues, **psr_args_factor)
         for obs in observable:
             for param_id, _ in uuid_to_eigen(obs).items():
                 # We need the embedded fixed params of the observable in the param_values dict


### PR DESCRIPTION
Reputting `n_eqs` in general PSR to limit the number of equations in case of multi-gap. Also, rescale the shift prefactor for cases of `Hamevo`.