### PR TITLE
Callbacks after optimization are run without modulo check

### DIFF
--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -14,7 +14,7 @@ from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 from torch.utils.tensorboard import SummaryWriter
 
-from qadence.ml_tools.config import Callback, TrainConfig
+from qadence.ml_tools.config import Callback, TrainConfig, run_callbacks
 from qadence.ml_tools.data import DictDataLoader, OptimizeResult, data_to_device
 from qadence.ml_tools.optimize_step import optimize_step
 from qadence.ml_tools.printing import (
@@ -262,10 +262,6 @@ def train(
             )
         ]
 
-    def run_callbacks(callback_iterable: list[Callback], opt_res: OptimizeResult) -> None:
-        for callback in callback_iterable:
-            callback(opt_res)
-
     callbacks_before_opt = [
         callback
         for callback in callbacks
@@ -349,7 +345,7 @@ def train(
 
     # Final callbacks, by default checkpointing and writing
     callbacks_after_opt = [callback for callback in callbacks if callback.call_after_opt]
-    run_callbacks(callbacks_after_opt, opt_result)
+    run_callbacks(callbacks_after_opt, opt_result, is_last_iteration=True)
 
     # writing hyperparameters
     if config.hyperparams:

--- a/qadence/ml_tools/train_no_grad.py
+++ b/qadence/ml_tools/train_no_grad.py
@@ -12,7 +12,7 @@ from torch.nn import Module
 from torch.utils.data import DataLoader
 from torch.utils.tensorboard import SummaryWriter
 
-from qadence.ml_tools.config import Callback, TrainConfig
+from qadence.ml_tools.config import Callback, TrainConfig, run_callbacks
 from qadence.ml_tools.data import DictDataLoader, OptimizeResult
 from qadence.ml_tools.parameters import get_parameters, set_parameters
 from qadence.ml_tools.printing import (
@@ -160,10 +160,6 @@ def train(
             )
         ]
 
-    def run_callbacks(callback_iterable: list[Callback], opt_res: OptimizeResult) -> None:
-        for callback in callback_iterable:
-            callback(opt_res)
-
     callbacks_end_opt = [
         callback
         for callback in callbacks
@@ -192,7 +188,7 @@ def train(
 
     # Final callbacks
     callbacks_after_opt = [callback for callback in callbacks if callback.call_after_opt]
-    run_callbacks(callbacks_after_opt, opt_result)
+    run_callbacks(callbacks_after_opt, opt_result, is_last_iteration=True)
 
     # close tracker
     if config.tracking_tool == ExperimentTrackingTool.TENSORBOARD:


### PR DESCRIPTION
For the last iteration, we impose that callbacks are run without the modulo check of `called_every`.