### PR TITLE
[Bug] Fix `write_checkpoint` bug 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ authors = [
     { name = "Ignacio Fernández Graña", email = "ignacio.fernandez-grana@pasqal.com" },
     { name = "Charles Moussa", email = "charles.moussa@pasqal.com" },
     { name = "Giorgio Tosti Balducci", email = "giorgio.tosti-balducci@pasqal.com" },
+    { name = "Daniele Cucurachi", email = "daniele.cucurachi@pasqal.com" },
 ]
 requires-python = ">=3.9"
 license = { text = "Apache 2.0" }

--- a/qadence/ml_tools/saveload.py
+++ b/qadence/ml_tools/saveload.py
@@ -72,7 +72,11 @@ def write_checkpoint(
     device = None
     try:
         # We extract the device from the pyqtorch native circuit
-        device = model.device if isinstance(QuantumModel, QNN) else next(model.parameters()).device
+        device = (
+            model.device
+            if isinstance(model, (QNN, QuantumModel))
+            else next(model.parameters()).device
+        )
         device = str(device).split(":")[0]  # in case of using several CUDA devices
     except Exception as e:
         msg = (


### PR DESCRIPTION
Closes #544 

This PR corrects the `isinstance` check in `write_checkpoint` to properly detect the device, resolving the issue described in #544 .