### PR TITLE
[Feature] Add possibility to modify the OptimizeResult during training in ml_tools

### DIFF
--- a/docs/tutorials/qml/ml_tools.md
+++ b/docs/tutorials/qml/ml_tools.md
@@ -80,7 +80,7 @@ The [`TrainConfig`][qadence.ml_tools.config.TrainConfig] tells `train_with_grad`
 how many epochs to train, in which intervals to print/log metrics and how often to store intermediate checkpoints.
 It is also possible to provide custom callback functions by instantiating a [`Callback`][qadence.ml_tools.config.Callback]
 with a function `callback` that only accept as argument an instance of [`OptimizeResult`][qadence.ml_tools.data.OptimizeResult] created within the `train` functions.
-One can also provide a `callback_condition` function, also only accepting an instance of [`OptimizeResult`][qadence.ml_tools.data.OptimizeResult], which returns True if `callback` should be called. If no `callback_condition` is provided, `callback` is called at every x epochs (specified by `Callback`'s `called_every` argument). We can also specify in which part of the training function the `Callback` will be applied. Note that if you need it, you can modify the instance of [`OptimizeResult`][qadence.ml_tools.data.OptimizeResult] created in the train functions by specifying `Callback`'s `modify_optimize_result`. For instance, we could add inputs to the `extra` field of [`OptimizeResult`][qadence.ml_tools.data.OptimizeResult] to be used within `callback`. An example code is shown below.
+One can also provide a `callback_condition` function, also only accepting an instance of [`OptimizeResult`][qadence.ml_tools.data.OptimizeResult], which returns True if `callback` should be called. If no `callback_condition` is provided, `callback` is called at every x epochs (specified by `Callback`'s `called_every` argument). We can also specify in which part of the training function the `Callback` will be applied. Note that if you need it, you can modify the instance of [`OptimizeResult`][qadence.ml_tools.data.OptimizeResult] created in the train functions by specifying `Callback`'s `modify_optimize_result` (as a function or a dictionary). For instance, we could add inputs to the `extra` field of [`OptimizeResult`][qadence.ml_tools.data.OptimizeResult] to be used within `callback`. An example code is shown below.
 
 ```python exec="on" source="material-block"
 from qadence.ml_tools import OptimizeResult, TrainConfig, Callback
@@ -88,11 +88,10 @@ from qadence.ml_tools import OptimizeResult, TrainConfig, Callback
 batch_size = 5
 n_epochs = 100
 
-def add_bias_extra(opt_res: OptimizeResult):
-    opt_res.extra.update({"model_bias": {name:param for name, param in self.named_parameters() if name in ['bias']}})
-
-custom_callback = Callback(lambda opt_res: print(opt_res.model.parameters()), callback_condition=lambda opt_res: opt_res.loss < 1.0e-03, called_every=10, call_end_epoch=True)
-custom_callback_extra = Callback(lambda opt_res: print(opt_res.extra), modify_optimize_result=add_bias_extra, call_end_epoch=False, call_after_opt=True)
+print_parameters = lambda opt_res: print(opt_res.model.parameters())
+condition_print = lambda opt_res: opt_res.loss < 1.0e-03
+modify_extra_opt_res = {"n_epochs": n_epochs}
+custom_callback = Callback(print_parameters, callback_condition=condition_print, modify_optimize_result=modify_extra_opt_res, called_every=10, call_end_epoch=True)
 
 config = TrainConfig(
     folder="some_path/",
@@ -100,7 +99,7 @@ config = TrainConfig(
     checkpoint_every=100,
     write_every=100,
     batch_size=batch_size,
-    callbacks = [custom_callback, custom_callback_extra]
+    callbacks = [custom_callback]
 )
 ```
 

--- a/qadence/ml_tools/__init__.py
+++ b/qadence/ml_tools/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .config import AnsatzConfig, Callback, FeatureMapConfig, TrainConfig
 from .constructors import create_ansatz, create_fm_blocks, observable_from_config
-from .data import DictDataLoader, InfiniteTensorDataset, to_dataloader
+from .data import DictDataLoader, InfiniteTensorDataset, OptimizeResult, to_dataloader
 from .models import QNN
 from .optimize_step import optimize_step as default_optimize_step
 from .parameters import get_parameters, num_parameters, set_parameters
@@ -23,6 +23,7 @@ __all__ = [
     "observable_from_config",
     "QNN",
     "TrainConfig",
+    "OptimizeResult",
     "Callback",
     "train_with_grad",
     "train_gradient_free",

--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -46,9 +46,10 @@ class Callback:
             OptimizeResult as first argument.
         callback_condition (CallbackConditionFunction | None, optional): Function that
             conditions the call to callback. Defaults to None.
-        modify_optimize_result (CallbackFunction): Function that modify the
-            OptimizeResult before callback. For instance, one can add inputs
-            to the `extra` argument to be used in callback.
+        modify_optimize_result (CallbackFunction | dict[str, Any] | None, optional):
+            Function that modify the OptimizeResult before callback.
+            For instance, one can change the `extra` (dict) argument to be used in callback.
+            If a dict is provided, the `extra` field of OptimizeResult is updated with the dict.
         called_every (int, optional): Callback to be called each `called_every` epoch.
             Defaults to 1.
             If callback_condition is None, we set
@@ -67,7 +68,7 @@ class Callback:
         self,
         callback: CallbackFunction,
         callback_condition: CallbackConditionFunction | None = None,
-        modify_optimize_result: CallbackFunction | None = None,
+        modify_optimize_result: CallbackFunction | dict[str, Any] | None = None,
         called_every: int = 1,
         call_before_opt: bool = False,
         call_end_epoch: bool = True,
@@ -81,8 +82,9 @@ class Callback:
                 OptimizeResult as ifrst argument.
             callback_condition (CallbackConditionFunction | None, optional): Function that
                 conditions the call to callback. Defaults to None.
-            modify_optimize_result (CallbackFunction): Function that modify the
-                OptimizeResult before callback.
+            modify_optimize_result (CallbackFunction | dict[str, Any] | None , optional):
+                Function that modify the OptimizeResult before callback. If a dict
+                is provided, this updates the `extra` field of OptimizeResult.
             called_every (int, optional): Callback to be called each `called_every` epoch.
                 Defaults to 1.
                 If callback_condition is None, we set
@@ -113,6 +115,13 @@ class Callback:
 
         if modify_optimize_result is None:
             self.modify_optimize_result = lambda opt_result: opt_result
+        elif isinstance(modify_optimize_result, dict):
+
+            def update_extra(opt_result: OptimizeResult) -> OptimizeResult:
+                opt_result.extra.update(modify_optimize_result)
+                return opt_result
+
+            self.modify_optimize_result = update_extra
         else:
             self.modify_optimize_result = modify_optimize_result
 

--- a/qadence/ml_tools/train_grad.py
+++ b/qadence/ml_tools/train_grad.py
@@ -194,7 +194,6 @@ def train(
             Callback(
                 lambda opt_res: print_metrics(opt_res.loss, opt_res.metrics, opt_res.iteration - 1),
                 called_every=config.print_every,
-                call_after_opt=True,
             )
         ]
 


### PR DESCRIPTION
Simply adding an extra `modify_optimize_result` argument in `Callback` to change the `OptimizeResult` instance passed during training. A showcase is available in docs.