### PR TITLE
[Feature] Add digital noise from PyQ

### DIFF
--- a/docs/content/block_system.md
+++ b/docs/content/block_system.md
@@ -189,3 +189,8 @@ More fine-grained control and better performance is provided via the high-level 
 2. Define a [`QuantumModel`](quantummodels.md) which differentiates, compiles and executes the circuit.
 
 Execution of more complex Qadence programs will be explored in the next tutorials.
+
+
+## Adding noise to gates
+
+It is possible to add noise to gates. Please refer to the noise tutorial [here](../tutorials/realistic_sims/noise.md).

--- a/docs/tutorials/realistic_sims/noise.md
+++ b/docs/tutorials/realistic_sims/noise.md
@@ -68,3 +68,46 @@ noisy_exp = model.expectation(measurement=measurement, noise=noise)
 print(f"noiseless = {noiseless_exp}") # markdown-exec: hide
 print(f"noisy = {noisy_exp}") # markdown-exec: hide
 ```
+
+## Digital noisy simulation
+
+When dealing with programs involving only digital operations, several options are made available from [PyQTorch](https://pasqal-io.github.io/pyqtorch/latest/noise/) via the `NoiseType`. One can define noisy digital operations with `DigitalNoise`as follows:
+
+```python exec="on" source="material-block" session="noise" result="json"
+from qadence import NoiseType, DigitalNoise, RX, run
+import torch
+
+noise = DigitalNoise(NoiseType.BITFLIP, error_probability = 0.2)
+noise = DigitalNoise.bitflip(error_probability = 0.2) # equivalent
+
+op = RX(0, torch.pi, noise = noise)
+
+print(run(op))
+```
+
+It is also possible to set a noise configuration to gates within a composite block or circuit as follows:
+
+```python exec="on" source="material-block" session="noise" result="json"
+from qadence import set_noise, chain
+
+n_qubits = 2
+
+block = chain(RX(i, f"theta_{i}") for i in range(n_qubits))
+
+noise = DigitalNoise.bitflip(error_probability = 0.1)
+
+# The function changes the block in place:
+set_noise(block, noise)
+print(run(block))
+```
+
+There is an extra optional argument to specify the type of block we want to apply noise to. E.g., let's say we want to apply noise only to `X` gates, a `target_class` argument can be passed with the corresponding block:
+
+```python exec="on" source="material-block" session="noise" result="json"
+from qadence import X
+block = chain(RX(0, "theta"), X(0))
+set_noise(block, noise, target_class = X)
+
+for block in block.blocks:
+    print(block.noise)
+```

--- a/qadence/backends/pyqtorch/convert_ops.py
+++ b/qadence/backends/pyqtorch/convert_ops.py
@@ -172,29 +172,39 @@ def convert_block(
         pyq_cls = getattr(pyq, block.name)
         if isinstance(block, ParametricBlock):
             if isinstance(block, U):
-                op = pyq_cls(qubit_support[0], *config.get_param_name(block))
+                op = pyq_cls(qubit_support[0], *config.get_param_name(block), noise=block.noise)
             else:
-                op = pyq_cls(qubit_support[0], extract_parameter(block, config))
+                op = pyq_cls(qubit_support[0], extract_parameter(block, config), noise=block.noise)
         else:
-            op = pyq_cls(qubit_support[0])
+            op = pyq_cls(qubit_support[0], noise=block.noise)  # type: ignore [attr-defined]
         return [op]
     elif isinstance(block, tuple(two_qubit_gateset)):
         pyq_cls = getattr(pyq, block.name)
         if isinstance(block, ParametricBlock):
-            op = pyq_cls(qubit_support[0], qubit_support[1], extract_parameter(block, config))
+            op = pyq_cls(
+                qubit_support[0],
+                qubit_support[1],
+                extract_parameter(block, config),
+                noise=block.noise,
+            )
         else:
-            op = pyq_cls(qubit_support[0], qubit_support[1])
+            op = pyq_cls(qubit_support[0], qubit_support[1], noise=block.noise)  # type: ignore [attr-defined]
         return [op]
     elif isinstance(block, tuple(three_qubit_gateset) + tuple(multi_qubit_gateset)):
         block_name = block.name[1:] if block.name.startswith("M") else block.name
         pyq_cls = getattr(pyq, block_name)
         if isinstance(block, ParametricBlock):
-            op = pyq_cls(qubit_support[:-1], qubit_support[-1], extract_parameter(block, config))
+            op = pyq_cls(
+                qubit_support[:-1],
+                qubit_support[-1],
+                extract_parameter(block, config),
+                noise=block.noise,
+            )
         else:
             if "CSWAP" in block_name:
-                op = pyq_cls(qubit_support[:-2], qubit_support[-2:])
+                op = pyq_cls(qubit_support[:-2], qubit_support[-2:], noise=block.noise)  # type: ignore [attr-defined]
             else:
-                op = pyq_cls(qubit_support[:-1], qubit_support[-1])
+                op = pyq_cls(qubit_support[:-1], qubit_support[-1], noise=block.noise)  # type: ignore [attr-defined]
         return [op]
     else:
         raise NotImplementedError(

--- a/qadence/backends/pyqtorch/convert_ops.py
+++ b/qadence/backends/pyqtorch/convert_ops.py
@@ -146,7 +146,7 @@ def convert_block(
             ]
 
     elif isinstance(block, MatrixBlock):
-        return [pyq.primitives.Primitive(block.matrix, block.qubit_support)]
+        return [pyq.primitives.Primitive(block.matrix, block.qubit_support, noise=block.noise)]
     elif isinstance(block, CompositeBlock):
         ops = list(flatten(*(convert_block(b, n_qubits, config) for b in block.blocks)))
         if isinstance(block, AddBlock):

--- a/qadence/backends/pyqtorch/convert_ops.py
+++ b/qadence/backends/pyqtorch/convert_ops.py
@@ -159,9 +159,13 @@ def convert_block(
         if isinstance(block, ProjectorBlock):
             projector = getattr(pyq, block.name)
             if block.name == OpName.N:
-                return [projector(target=qubit_support)]
+                return [projector(target=qubit_support, noise=block.noise)]
             else:
-                return [projector(qubit_support=qubit_support, ket=block.ket, bra=block.bra)]
+                return [
+                    projector(
+                        qubit_support=qubit_support, ket=block.ket, bra=block.bra, noise=block.noise
+                    )
+                ]
         else:
             return [getattr(pyq, block.name)(qubit_support[0])]
     elif isinstance(block, tuple(single_qubit_gateset)):

--- a/qadence/backends/utils.py
+++ b/qadence/backends/utils.py
@@ -10,6 +10,7 @@ import torch
 from numpy.typing import ArrayLike
 from pyqtorch.apply import apply_operator
 from pyqtorch.primitives import Parametric as PyQParametric
+from pyqtorch.utils import DensityMatrix
 from torch import (
     Tensor,
     cat,
@@ -121,7 +122,14 @@ def pyqify(state: Tensor, n_qubits: int = None) -> ArrayLike:
 
 
 def unpyqify(state: Tensor) -> Tensor:
-    """Convert a state of shape [2] * n_qubits + [batch_size] to (batch_size, 2**n_qubits)."""
+    """
+    Convert a state of shape [2] * n_qubits + [batch_size] to (batch_size, 2**n_qubits).
+
+    Convert a density matrix of shape (2**n_qubits, 2**n_qubits, batch_size)
+    to (batch_size, 2**n_qubits, 2**n_qubits)
+    """
+    if isinstance(state, DensityMatrix):
+        return torch.einsum("ijk->kij", state)
     return torch.flatten(state, start_dim=0, end_dim=-2).t()
 
 

--- a/qadence/blocks/matrix.py
+++ b/qadence/blocks/matrix.py
@@ -8,6 +8,7 @@ import torch
 from torch.linalg import eigvals
 
 from qadence.blocks import PrimitiveBlock
+from qadence.noise.protocols import DigitalNoise
 
 logger = getLogger(__name__)
 
@@ -64,6 +65,7 @@ class MatrixBlock(PrimitiveBlock):
         self,
         matrix: torch.Tensor | np.ndarray,
         qubit_support: tuple[int, ...],
+        noise: DigitalNoise | None = None,
         check_unitary: bool = True,
         check_hermitian: bool = False,
     ) -> None:
@@ -82,7 +84,7 @@ class MatrixBlock(PrimitiveBlock):
             if not self.is_unitary(matrix):
                 logger.warning("Provided matrix is not unitary.")
         self.matrix = matrix.clone()
-        super().__init__(qubit_support)
+        super().__init__(qubit_support, noise)
 
     @cached_property
     def eigenvalues_generator(self) -> torch.Tensor:

--- a/qadence/blocks/primitive.py
+++ b/qadence/blocks/primitive.py
@@ -11,7 +11,7 @@ from rich.panel import Panel
 from rich.tree import Tree
 
 from qadence.blocks.abstract import AbstractBlock
-from qadence.noise import DigitalNoise
+from qadence.noise.protocols import DigitalNoise
 from qadence.parameters import (
     Parameter,
     ParamMap,

--- a/qadence/blocks/primitive.py
+++ b/qadence/blocks/primitive.py
@@ -11,6 +11,7 @@ from rich.panel import Panel
 from rich.tree import Tree
 
 from qadence.blocks.abstract import AbstractBlock
+from qadence.noise import DigitalNoise
 from qadence.parameters import (
     Parameter,
     ParamMap,
@@ -33,12 +34,21 @@ class PrimitiveBlock(AbstractBlock):
 
     name = "PrimitiveBlock"
 
-    def __init__(self, qubit_support: tuple[int, ...]):
+    def __init__(
+        self,
+        qubit_support: tuple[int, ...],
+        noise: DigitalNoise | None = None,
+    ):
         self._qubit_support = qubit_support
+        self._noise = noise
 
     @property
     def qubit_support(self) -> Tuple[int, ...]:
         return self._qubit_support
+
+    @property
+    def noise(self) -> DigitalNoise | None:
+        return self._noise
 
     def digital_decomposition(self) -> AbstractBlock:
         """Decomposition into purely digital gates.
@@ -357,14 +367,19 @@ class ControlBlock(PrimitiveBlock):
     control: tuple[int, ...]
     target: tuple[int, ...]
 
-    def __init__(self, control: tuple[int, ...], target_block: PrimitiveBlock) -> None:
+    def __init__(
+        self,
+        control: tuple[int, ...],
+        target_block: PrimitiveBlock,
+        noise: DigitalNoise | None = None,
+    ) -> None:
         self.control = control
         self.blocks = (target_block,)
         self.target = target_block.qubit_support
 
         # using tuple expansion because some control operations could
         # have multiple targets, e.g. CSWAP
-        super().__init__((*control, *self.target))  # target_block.qubit_support[0]))
+        super().__init__((*control, *self.target), noise=noise)  # target_block.qubit_support[0]))
 
     @property
     def n_controls(self) -> int:
@@ -416,11 +431,16 @@ class ParametricControlBlock(ParametricBlock):
     control: tuple[int, ...] = ()
     blocks: tuple[ParametricBlock, ...]
 
-    def __init__(self, control: tuple[int, ...], target_block: ParametricBlock) -> None:
+    def __init__(
+        self,
+        control: tuple[int, ...],
+        target_block: ParametricBlock,
+        noise: DigitalNoise | None = None,
+    ) -> None:
         self.blocks = (target_block,)
         self.control = control
         self.parameters = target_block.parameters
-        super().__init__((*control, *target_block.qubit_support))
+        super().__init__((*control, *target_block.qubit_support), noise=noise)
 
     @property
     def n_controls(self) -> int:
@@ -497,6 +517,7 @@ class ProjectorBlock(PrimitiveBlock):
         ket: str,
         bra: str,
         qubit_support: int | tuple[int, ...],
+        noise: DigitalNoise | None = None,
     ) -> None:
         """
         Arguments:
@@ -522,4 +543,4 @@ class ProjectorBlock(PrimitiveBlock):
 
         self.ket = ket
         self.bra = bra
-        super().__init__(qubit_support)
+        super().__init__(qubit_support, noise=noise)

--- a/qadence/noise/__init__.py
+++ b/qadence/noise/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .protocols import Noise
+from .protocols import DigitalNoise, Noise
 
 # Modules to be automatically added to the qadence namespace
-__all__ = ["Noise"]
+__all__ = ["Noise", "DigitalNoise"]

--- a/qadence/noise/protocols.py
+++ b/qadence/noise/protocols.py
@@ -4,9 +4,14 @@ import importlib
 from dataclasses import dataclass
 from typing import Callable, Counter, cast
 
+from pyqtorch.noise import NoiseProtocol
+
 PROTOCOL_TO_MODULE = {
     "readout": "qadence.noise.readout",
 }
+
+# Temporary solution
+DigitalNoise = NoiseProtocol
 
 
 @dataclass

--- a/qadence/operations/control_ops.py
+++ b/qadence/operations/control_ops.py
@@ -18,7 +18,7 @@ from qadence.blocks.utils import (
     chain,
     kron,
 )
-from qadence.noise import DigitalNoise
+from qadence.noise.protocols import DigitalNoise
 from qadence.parameters import (
     Parameter,
     evaluate,

--- a/qadence/operations/control_ops.py
+++ b/qadence/operations/control_ops.py
@@ -18,6 +18,7 @@ from qadence.blocks.utils import (
     chain,
     kron,
 )
+from qadence.noise import DigitalNoise
 from qadence.parameters import (
     Parameter,
     evaluate,
@@ -35,9 +36,9 @@ class CNOT(ControlBlock):
 
     name = OpName.CNOT
 
-    def __init__(self, control: int, target: int) -> None:
+    def __init__(self, control: int, target: int, noise: DigitalNoise | None = None) -> None:
         self.generator = kron(N(control), X(target) - I(target))
-        super().__init__((control,), X(target))
+        super().__init__((control,), X(target), noise=noise)
 
     @property
     def eigenvalues_generator(self) -> Tensor:
@@ -63,9 +64,11 @@ class CNOT(ControlBlock):
 class MCZ(ControlBlock):
     name = OpName.MCZ
 
-    def __init__(self, control: tuple[int, ...], target: int) -> None:
+    def __init__(
+        self, control: tuple[int, ...], target: int, noise: DigitalNoise | None = None
+    ) -> None:
         self.generator = kron(*[N(qubit) for qubit in control], Z(target) - I(target))
-        super().__init__(control, Z(target))
+        super().__init__(control, Z(target), noise=noise)
 
     @property
     def eigenvalues_generator(self) -> Tensor:
@@ -93,8 +96,8 @@ class CZ(MCZ):
 
     name = OpName.CZ
 
-    def __init__(self, control: int, target: int) -> None:
-        super().__init__((control,), target)
+    def __init__(self, control: int, target: int, noise: DigitalNoise | None = None) -> None:
+        super().__init__((control,), target, noise=noise)
 
 
 class MCRX(ParametricControlBlock):
@@ -105,9 +108,10 @@ class MCRX(ParametricControlBlock):
         control: tuple[int, ...],
         target: int,
         parameter: Parameter | TNumber | sympy.Expr | str,
+        noise: DigitalNoise | None = None,
     ) -> None:
         self.generator = kron(*[N(qubit) for qubit in control], X(target))
-        super().__init__(control, RX(target, parameter))
+        super().__init__(control, RX(target, parameter), noise=noise)
 
     @classmethod
     def num_parameters(cls) -> int:
@@ -136,8 +140,9 @@ class CRX(MCRX):
         control: int,
         target: int,
         parameter: Parameter | TNumber | sympy.Expr | str,
+        noise: DigitalNoise | None = None,
     ):
-        super().__init__((control,), target, parameter)
+        super().__init__((control,), target, parameter, noise=noise)
 
 
 class MCRY(ParametricControlBlock):
@@ -148,9 +153,10 @@ class MCRY(ParametricControlBlock):
         control: tuple[int, ...],
         target: int,
         parameter: Parameter | TNumber | sympy.Expr | str,
+        noise: DigitalNoise | None = None,
     ) -> None:
         self.generator = kron(*[N(qubit) for qubit in control], Y(target))
-        super().__init__(control, RY(target, parameter))
+        super().__init__(control, RY(target, parameter), noise=noise)
 
     @classmethod
     def num_parameters(cls) -> int:
@@ -175,12 +181,9 @@ class CRY(MCRY):
     name = OpName.CRY
 
     def __init__(
-        self,
-        control: int,
-        target: int,
-        parameter: TParameter,
+        self, control: int, target: int, parameter: TParameter, noise: DigitalNoise | None = None
     ):
-        super().__init__((control,), target, parameter)
+        super().__init__((control,), target, parameter, noise=noise)
 
 
 class MCRZ(ParametricControlBlock):
@@ -191,9 +194,10 @@ class MCRZ(ParametricControlBlock):
         control: tuple[int, ...],
         target: int,
         parameter: Parameter | TNumber | sympy.Expr | str,
+        noise: DigitalNoise | None = None,
     ) -> None:
         self.generator = kron(*[N(qubit) for qubit in control], Z(target))
-        super().__init__(control, RZ(target, parameter))
+        super().__init__(control, RZ(target, parameter), noise=noise)
 
     @classmethod
     def num_parameters(cls) -> int:
@@ -222,8 +226,9 @@ class CRZ(MCRZ):
         control: int,
         target: int,
         parameter: Parameter | TNumber | sympy.Expr | str,
+        noise: DigitalNoise | None = None,
     ):
-        super().__init__((control,), target, parameter)
+        super().__init__((control,), target, parameter, noise=noise)
 
 
 class MCPHASE(ParametricControlBlock):
@@ -234,9 +239,10 @@ class MCPHASE(ParametricControlBlock):
         control: tuple[int, ...],
         target: int,
         parameter: Parameter | TNumber | sympy.Expr | str,
+        noise: DigitalNoise | None = None,
     ) -> None:
         self.generator = kron(*[N(qubit) for qubit in control], Z(target) - I(target))
-        super().__init__(control, PHASE(target, parameter))
+        super().__init__(control, PHASE(target, parameter), noise=noise)
 
     @classmethod
     def num_parameters(cls) -> int:
@@ -276,8 +282,9 @@ class CPHASE(MCPHASE):
         control: int,
         target: int,
         parameter: Parameter | TNumber | sympy.Expr | str,
+        noise: DigitalNoise | None = None,
     ):
-        super().__init__((control,), target, parameter)
+        super().__init__((control,), target, parameter, noise=noise)
 
 
 class CSWAP(ControlBlock):
@@ -285,7 +292,13 @@ class CSWAP(ControlBlock):
 
     name = OpName.CSWAP
 
-    def __init__(self, control: int | tuple[int, ...], target1: int, target2: int) -> None:
+    def __init__(
+        self,
+        control: int | tuple[int, ...],
+        target1: int,
+        target2: int,
+        noise: DigitalNoise | None = None,
+    ) -> None:
         if isinstance(control, tuple):
             control = control[0]
 
@@ -303,7 +316,7 @@ class CSWAP(ControlBlock):
             + kron(a00p, a21, a12)
         )
         self.generator = no_effect + swap_effect
-        super().__init__((control,), SWAP(target1, target2))
+        super().__init__((control,), SWAP(target1, target2), noise=noise)
 
     @property
     def eigenvalues_generator(self) -> Tensor:
@@ -321,9 +334,11 @@ class CSWAP(ControlBlock):
 class Toffoli(ControlBlock):
     name = OpName.TOFFOLI
 
-    def __init__(self, control: tuple[int, ...], target: int) -> None:
+    def __init__(
+        self, control: tuple[int, ...], target: int, noise: DigitalNoise | None = None
+    ) -> None:
         self.generator = kron(*[N(qubit) for qubit in control], X(target) - I(target))
-        super().__init__(control, X(target))
+        super().__init__(control, X(target), noise=noise)
 
     @property
     def n_qubits(self) -> int:

--- a/qadence/operations/parametric.py
+++ b/qadence/operations/parametric.py
@@ -15,6 +15,7 @@ from qadence.blocks.utils import (
     add,  # noqa
     chain,
 )
+from qadence.noise import DigitalNoise
 from qadence.parameters import (
     Parameter,
     ParamMap,
@@ -32,10 +33,15 @@ class PHASE(ParametricBlock):
 
     name = OpName.PHASE
 
-    def __init__(self, target: int, parameter: Parameter | TNumber | sympy.Expr | str):
+    def __init__(
+        self,
+        target: int,
+        parameter: Parameter | TNumber | sympy.Expr | str,
+        noise: DigitalNoise | None = None,
+    ) -> None:
         self.parameters = ParamMap(parameter=parameter)
         self.generator = I(target) - Z(target)
-        super().__init__((target,))
+        super().__init__((target,), noise=noise)
 
     @classmethod
     def num_parameters(cls) -> int:
@@ -56,13 +62,18 @@ class RX(ParametricBlock):
 
     name = OpName.RX
 
-    def __init__(self, target: int, parameter: Parameter | TParameter | ParamMap):
+    def __init__(
+        self,
+        target: int,
+        parameter: Parameter | TParameter | ParamMap,
+        noise: DigitalNoise | None = None,
+    ) -> None:
         # TODO: should we give them more meaningful names? like 'angle'?
         self.parameters = (
             parameter if isinstance(parameter, ParamMap) else ParamMap(parameter=parameter)
         )
         self.generator = X(target)
-        super().__init__((target,))
+        super().__init__((target,), noise=noise)
 
     @classmethod
     def num_parameters(cls) -> int:
@@ -84,12 +95,17 @@ class RY(ParametricBlock):
 
     name = OpName.RY
 
-    def __init__(self, target: int, parameter: Parameter | TParameter | ParamMap):
+    def __init__(
+        self,
+        target: int,
+        parameter: Parameter | TParameter | ParamMap,
+        noise: DigitalNoise | None = None,
+    ) -> None:
         self.parameters = (
             parameter if isinstance(parameter, ParamMap) else ParamMap(parameter=parameter)
         )
         self.generator = Y(target)
-        super().__init__((target,))
+        super().__init__((target,), noise=noise)
 
     @classmethod
     def num_parameters(cls) -> int:
@@ -111,12 +127,17 @@ class RZ(ParametricBlock):
 
     name = OpName.RZ
 
-    def __init__(self, target: int, parameter: Parameter | TParameter | ParamMap):
+    def __init__(
+        self,
+        target: int,
+        parameter: Parameter | TParameter | ParamMap,
+        noise: DigitalNoise | None = None,
+    ) -> None:
         self.parameters = (
             parameter if isinstance(parameter, ParamMap) else ParamMap(parameter=parameter)
         )
         self.generator = Z(target)
-        super().__init__((target,))
+        super().__init__((target,), noise=noise)
 
     @classmethod
     def num_parameters(cls) -> int:
@@ -147,10 +168,11 @@ class U(ParametricBlock):
         phi: Parameter | TParameter,
         theta: Parameter | TParameter,
         omega: Parameter | TParameter,
-    ):
+        noise: DigitalNoise | None = None,
+    ) -> None:
         self.parameters = ParamMap(phi=phi, theta=theta, omega=omega)
         self.generator = chain(Z(target), Y(target), Z(target))
-        super().__init__((target,))
+        super().__init__((target,), noise=noise)
 
     @classmethod
     def num_parameters(cls) -> int:

--- a/qadence/operations/parametric.py
+++ b/qadence/operations/parametric.py
@@ -15,7 +15,7 @@ from qadence.blocks.utils import (
     add,  # noqa
     chain,
 )
-from qadence.noise import DigitalNoise
+from qadence.noise.protocols import DigitalNoise
 from qadence.parameters import (
     Parameter,
     ParamMap,

--- a/qadence/operations/primitive.py
+++ b/qadence/operations/primitive.py
@@ -18,6 +18,7 @@ from qadence.blocks.utils import (
     chain,
     kron,
 )
+from qadence.noise import DigitalNoise
 from qadence.parameters import (
     Parameter,
 )
@@ -31,8 +32,8 @@ class X(PrimitiveBlock):
 
     name = OpName.X
 
-    def __init__(self, target: int):
-        super().__init__((target,))
+    def __init__(self, target: int, noise: DigitalNoise | None = None) -> None:
+        super().__init__((target,), noise=noise)
 
     @property
     def generator(self) -> AbstractBlock:
@@ -52,8 +53,8 @@ class Y(PrimitiveBlock):
 
     name = OpName.Y
 
-    def __init__(self, target: int):
-        super().__init__((target,))
+    def __init__(self, target: int, noise: DigitalNoise | None = None) -> None:
+        super().__init__((target,), noise=noise)
 
     @property
     def generator(self) -> AbstractBlock:
@@ -73,8 +74,8 @@ class Z(PrimitiveBlock):
 
     name = OpName.Z
 
-    def __init__(self, target: int):
-        super().__init__((target,))
+    def __init__(self, target: int, noise: DigitalNoise | None = None) -> None:
+        super().__init__((target,), noise=noise)
 
     @property
     def generator(self) -> AbstractBlock:
@@ -94,8 +95,8 @@ class I(PrimitiveBlock):
 
     name = OpName.I
 
-    def __init__(self, target: int):
-        super().__init__((target,))
+    def __init__(self, target: int, noise: DigitalNoise | None = None) -> None:
+        super().__init__((target,), noise=noise)
 
     def __ixor__(self, other: AbstractBlock | int) -> AbstractBlock:
         if not isinstance(other, AbstractBlock):
@@ -137,8 +138,9 @@ class Projector(ProjectorBlock):
         ket: str,
         bra: str,
         qubit_support: int | tuple[int, ...],
-    ):
-        super().__init__(ket=ket, bra=bra, qubit_support=qubit_support)
+        noise: DigitalNoise | None = None,
+    ) -> None:
+        super().__init__(ket=ket, bra=bra, qubit_support=qubit_support, noise=noise)
 
     @property
     def generator(self) -> None:
@@ -154,8 +156,13 @@ class N(Projector):
 
     name = OpName.N
 
-    def __init__(self, target: int, state: str = "1"):
-        super().__init__(ket=state, bra=state, qubit_support=(target,))
+    def __init__(
+        self,
+        target: int,
+        state: str = "1",
+        noise: DigitalNoise | None = None,
+    ) -> None:
+        super().__init__(ket=state, bra=state, qubit_support=(target,), noise=noise)
 
     @property
     def generator(self) -> None:
@@ -175,9 +182,13 @@ class S(PrimitiveBlock):
 
     name = OpName.S
 
-    def __init__(self, target: int):
+    def __init__(
+        self,
+        target: int,
+        noise: DigitalNoise | None = None,
+    ) -> None:
         self.generator = I(target) - Z(target)
-        super().__init__((target,))
+        super().__init__((target,), noise=noise)
 
     @property
     def eigenvalues_generator(self) -> Tensor:
@@ -196,9 +207,13 @@ class SDagger(PrimitiveBlock):
 
     name = OpName.SDAGGER
 
-    def __init__(self, target: int):
+    def __init__(
+        self,
+        target: int,
+        noise: DigitalNoise | None = None,
+    ) -> None:
         self.generator = I(target) - Z(target)
-        super().__init__((target,))
+        super().__init__((target,), noise=noise)
 
     @property
     def eigenvalues_generator(self) -> Tensor:
@@ -217,9 +232,13 @@ class H(PrimitiveBlock):
 
     name = OpName.H
 
-    def __init__(self, target: int):
+    def __init__(
+        self,
+        target: int,
+        noise: DigitalNoise | None = None,
+    ) -> None:
         self.generator = (1 / np.sqrt(2)) * (X(target) + Z(target) - np.sqrt(2) * I(target))
-        super().__init__((target,))
+        super().__init__((target,), noise=noise)
 
     @property
     def eigenvalues_generator(self) -> Tensor:
@@ -275,9 +294,13 @@ class T(PrimitiveBlock):
 
     name = OpName.T
 
-    def __init__(self, target: int):
+    def __init__(
+        self,
+        target: int,
+        noise: DigitalNoise | None = None,
+    ) -> None:
         self.generator = I(target) - Z(target)
-        super().__init__((target,))
+        super().__init__((target,), noise)
 
     @property
     def eigenvalues_generator(self) -> Tensor:
@@ -301,9 +324,13 @@ class TDagger(PrimitiveBlock):
     # FIXME: this gate is not support by any backend
     name = "T_dagger"
 
-    def __init__(self, target: int):
+    def __init__(
+        self,
+        target: int,
+        noise: DigitalNoise | None = None,
+    ) -> None:
         self.generator = I(target) - Z(target)
-        super().__init__((target,))
+        super().__init__((target,), noise)
 
     @property
     def eigenvalues_generator(self) -> Tensor:
@@ -326,7 +353,12 @@ class SWAP(PrimitiveBlock):
 
     name = OpName.SWAP
 
-    def __init__(self, control: int, target: int) -> None:
+    def __init__(
+        self,
+        control: int,
+        target: int,
+        noise: DigitalNoise | None = None,
+    ) -> None:
         a11 = 0.5 * (Z(control) - I(control))
         a22 = -0.5 * (Z(target) + I(target))
         a12 = 0.5 * (chain(X(control), Z(control)) + X(control))
@@ -334,7 +366,7 @@ class SWAP(PrimitiveBlock):
         self.generator = (
             kron(-1.0 * a22, a11) + kron(-1.0 * a11, a22) + kron(a12, a21) + kron(a21, a12)
         )
-        super().__init__((control, target))
+        super().__init__((control, target), noise=noise)
 
     @property
     def eigenvalues_generator(self) -> Tensor:

--- a/qadence/operations/primitive.py
+++ b/qadence/operations/primitive.py
@@ -18,7 +18,7 @@ from qadence.blocks.utils import (
     chain,
     kron,
 )
-from qadence.noise import DigitalNoise
+from qadence.noise.protocols import DigitalNoise
 from qadence.parameters import (
     Parameter,
 )

--- a/qadence/transpile/__init__.py
+++ b/qadence/transpile/__init__.py
@@ -12,6 +12,7 @@ from .circuit import fill_identities
 from .digitalize import digitalize
 from .flatten import flatten
 from .invert import invert_endianness, reassign
+from .noise import set_noise
 from .transpile import blockfn_to_circfn, transpile
 
-__all__ = ["set_trainable", "invert_endianness"]
+__all__ = ["set_trainable", "invert_endianness", "set_noise"]

--- a/qadence/transpile/noise.py
+++ b/qadence/transpile/noise.py
@@ -6,10 +6,11 @@ from qadence.noise.protocols import DigitalNoise
 
 from .apply_fn import apply_fn_to_blocks
 
+
 def _set_noise(
     block: AbstractBlock,
     noise: DigitalNoise | None,
-    target_class: type[AbstractBlock] | None = None
+    target_class: type[AbstractBlock] | None = None,
 ) -> AbstractBlock:
     """Changes the noise protocol of a given block in place."""
     if target_class is not None:
@@ -19,11 +20,12 @@ def _set_noise(
         block._noise = noise  # type: ignore [attr-defined]
 
     return block
-    
+
+
 def set_noise(
     circuit: QuantumCircuit | AbstractBlock,
     noise: DigitalNoise | None,
-    target_class: AbstractBlock | None = None
+    target_class: AbstractBlock | None = None,
 ) -> QuantumCircuit | AbstractBlock:
     """
     Parses a `QuantumCircuit` or `CompositeBlock` to add noise to specific gates.

--- a/qadence/transpile/noise.py
+++ b/qadence/transpile/noise.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from qadence.blocks.abstract import AbstractBlock
+from qadence.circuit import QuantumCircuit
+from qadence.noise.protocols import DigitalNoise
+
+from .apply_fn import apply_fn_to_blocks
+
+def _set_noise(
+    block: AbstractBlock,
+    noise: DigitalNoise | None,
+    target_class: type[AbstractBlock] | None = None
+) -> AbstractBlock:
+    """Changes the noise protocol of a given block in place."""
+    if target_class is not None:
+        if isinstance(block, target_class):
+            block._noise = noise  # type: ignore [attr-defined]
+    else:
+        block._noise = noise  # type: ignore [attr-defined]
+
+    return block
+    
+def set_noise(
+    circuit: QuantumCircuit | AbstractBlock,
+    noise: DigitalNoise | None,
+    target_class: AbstractBlock | None = None
+) -> QuantumCircuit | AbstractBlock:
+    """
+    Parses a `QuantumCircuit` or `CompositeBlock` to add noise to specific gates.
+
+    Changes the input in place.
+
+    Arguments:
+        circuit: the circuit or block to parse.
+        noise: the DigitalNoise protocol to change to, or `None` to remove the noise.
+        target_class: optional class to selectively add noise to.
+    """
+    is_circuit_input = isinstance(circuit, QuantumCircuit)
+
+    input_block: AbstractBlock = circuit.block if is_circuit_input else circuit  # type: ignore
+
+    output_block = apply_fn_to_blocks(input_block, _set_noise, noise, target_class)
+
+    return circuit

--- a/qadence/types.py
+++ b/qadence/types.py
@@ -8,6 +8,7 @@ import numpy as np
 import sympy
 from matplotlib.figure import Figure
 from numpy.typing import ArrayLike
+from pyqtorch.noise import NoiseType
 from pyqtorch.utils import SolverType
 from torch import Tensor, pi
 from torch.nn import Module
@@ -51,6 +52,7 @@ __all__ = [
     "SerializationFormat",
     "PI",
     "SolverType",
+    "NoiseType",
 ]  # type: ignore
 
 


### PR DESCRIPTION
## Description

Ongoing work in adding the noise from PyQ. Supersedes https://github.com/pasqal-io/qadence/pull/469.

Currently in this branch the basics should be working:

```
from qadence import NoiseType, DigitalNoise
from qadence import RX, run

noise = DigitalNoise(NoiseType.BITFLIP, error_probability = 0.2)
noise = DigitalNoise.bitflip(error_probability = 0.2) # equivalent

op = RX(0, torch.pi, noise = noise)

run(op)

---

DensityMatrix([[[0.2000+0.0000e+00j, 0.0000+3.6739e-17j],
                [0.0000-3.6739e-17j, 0.8000+0.0000e+00j]]])
```

Note that currently the `DigitalNoise` is simply a name alias for the `NoiseProtocol` class directly from PyQ, which you can find here: https://github.com/pasqal-io/pyqtorch/blob/main/pyqtorch/noise/protocol.py. 

The approach in https://github.com/pasqal-io/qadence/pull/469 was instead to change the `Noise` dataclass in `qadence.noise.protocols` to include the same options, but then there was already an option there called `DEPOLARIZING` which got changed to `DEPOLARIZING_PYQ`... I am not so sure what is the best approach here, this should be revised.

Furthermore, I have also drafted a transpilation function to add noise to gates within a composite block or circuit. It works like this:

```
from qadence import RX, DigitalNoise, set_noise, chain, run

n_qubits = 2

block = chain(RX(i, f"theta_{i}") for i in range(n_qubits))

noise = DigitalNoise.bitflip(error_probability = 0.1)

# The function changes the block in place:
set_noise(block, noise)

run(block)
```

The code above should add the defined bitflip protocol to every gate in the block. It should also work if it is a `QuantumCircuit`. There is an extra optional argument to specify the type of block we want to apply noise to. E.g., let's say we want to apply noise only to `X` gates, then it will run an `if isinstance(block, target_class): ...` at every leaf block in the block tree:

```
from qadence import RX, X, DigitalNoise, set_noise, chain, run

n_qubits = 2

block = chain(RX(i, f"theta_{i}") for i in range(n_qubits))

noise = DigitalNoise.bitflip(error_probability = 0.1)

# The function changes the block in place:
set_noise(block, noise, target_class = X)

run(block)
```

The snippet above will just return a statevector because there exists no `X` gates in that composite block. We can also try to print the noise for each of the gates and see that it works:
 
```
from qadence import RX, X, DigitalNoise, set_noise, chain, run

n_qubits = 2

block = chain(RX(0, "theta"), X(0))

noise = DigitalNoise.bitflip(error_probability = 0.1)

set_noise(block, noise, target_class = X)

for block in block.blocks:
    print(block.noise)

---

> None
> BitFlip(prob: 0.1)
```

## What is left to do:

- Serialization: to check the `_to_dict` and `_from_dict` stuff in https://github.com/pasqal-io/qadence/pull/469
- Including the noise in each block string: if added, check how it behaves with visualization.
- Properly review the code, and check if something else from https://github.com/pasqal-io/qadence/pull/469 should be added. See about harmonizing the `DigitalNoise` with the `Noise` and etc... I like the interface of the `NoiseProtocol` from pyq, so it would be nice to still keep it when using it in Qadence.
- Add tests! While writing some finals things for this MR description I think I ran an instance of `set_noise` that did not apply the noise correctly... But now I was trying to replicate it to put it here and I couldn't 😅 So yes for sure test it thoroughly.
- Docs! I think this should have a nice separate page in the Contents section: https://pasqal-io.github.io/qadence/latest/content/block_system/