### PR TITLE
[Feature] Add tagging option to QNN configs

### DIFF
--- a/qadence/ml_tools/config.py
+++ b/qadence/ml_tools/config.py
@@ -447,6 +447,13 @@ class FeatureMapConfig:
     assign `t, x = xs[:,0], xs[:,1]`.
     """
 
+    tag: str | None = None
+    """
+    String to indicate the name tag of the feature map.
+
+    Defaults to None, in which case no tag will be applied.
+    """
+
     def __post_init__(self) -> None:
         if self.multivariate_strategy == MultivariateStrategy.PARALLEL and self.num_features > 1:
             assert (
@@ -605,6 +612,13 @@ class AnsatzConfig:
 
     param_prefix: str = "theta"
     """The base bame of the variational parameter."""
+
+    tag: str | None = None
+    """
+    String to indicate the name tag of the ansatz.
+
+    Defaults to None, in which case no tag will be applied.
+    """
 
     def __post_init__(self) -> None:
         if self.ansatz_type == AnsatzType.IIA:

--- a/qadence/ml_tools/constructors.py
+++ b/qadence/ml_tools/constructors.py
@@ -7,7 +7,7 @@ from qadence.backend import BackendConfiguration
 from qadence.blocks import chain, kron
 from qadence.blocks.abstract import AbstractBlock
 from qadence.blocks.composite import ChainBlock, KronBlock
-from qadence.blocks.utils import add
+from qadence.blocks.utils import add, tag
 from qadence.circuit import QuantumCircuit
 from qadence.constructors import (
     analog_feature_map,
@@ -774,10 +774,15 @@ def build_qnn_from_configs(
             fm_blocks=fm_blocks,
             ansatz_config=ansatz_config,
         )
+        if isinstance(fm_config.tag, str):
+            tag(full_fm, fm_config.tag)
         inputs = fm_config.inputs
         blocks.append(full_fm)
 
-    blocks.append(create_ansatz(register=register, config=ansatz_config))
+    ansatz = create_ansatz(register=register, config=ansatz_config)
+    if isinstance(ansatz_config.tag, str):
+        tag(ansatz, ansatz_config.tag)
+    blocks.append(ansatz)
 
     circ = QuantumCircuit(register, *blocks)
 


### PR DESCRIPTION
Adds a `tag` variable to the `FeatureMapConfig` and the `AnsatzConfig` dataclasses to specify their tag name. Then, in `build_qnn_from_configs()` the FM and ansatz are tagged if a tag name has been provided. 

This functionality is needed in some algorithms where certain blocks need to be identified after the QNN creation (e.g. to make them non trainable at some point)