### PR TITLE
[Drawing, Bug] Don't construct single operator composite blocks

### DIFF
--- a/qadence/blocks/utils.py
+++ b/qadence/blocks/utils.py
@@ -45,7 +45,10 @@ def _construct(
 ) -> TCompositeBlock:
     if len(args) == 1 and isinstance(args[0], Generator):
         args = tuple(args[0])
-    return Block([b for b in args])  # type: ignore [arg-type]
+    if len(args) == 1:
+        return args[0]  # type: ignore [return-value]
+    else:
+        return Block([b for b in args])  # type: ignore [arg-type]
 
 
 def chain(*args: Union[AbstractBlock, Generator, List[AbstractBlock]]) -> ChainBlock:


### PR DESCRIPTION
There was a bug when drawing certain composite operators which I tracked down to the `fill_identities` function in `qadence.transpile.block`. The easiest way to replicate is to do:

```
from qadence import *
from qadence.draw import display

display(CNOT(0, 2)) # WORKS
display(kron(CNOT(0, 2))) # BREAKS
```

Doing `kron(CNOT(0, 2))` does not really make sense, and we currently allow all composite operations to have a single operation. Disabling that does fix the drawing problem, but it's not really backward compatible, so it could be a bit dangerous to do at this point.