### PR TITLE
Fix empy dict argument default to None

### DIFF
--- a/qadence/analog/device.py
+++ b/qadence/analog/device.py
@@ -49,7 +49,7 @@ class RydbergDevice:
             )
 
     def _to_dict(self) -> dict:
-        device_dict = {}
+        device_dict = dict()
         for field in fields(self):
             if field.name != "pattern":
                 device_dict[field.name] = getattr(self, field.name)

--- a/qadence/blocks/abstract.py
+++ b/qadence/blocks/abstract.py
@@ -263,7 +263,7 @@ class AbstractBlock(ABC):
 
     @classmethod
     def _from_json(cls, path: str | Path) -> AbstractBlock:
-        d: dict = {}
+        d: dict = dict()
         if isinstance(path, str):
             path = Path(path)
         try:

--- a/qadence/circuit.py
+++ b/qadence/circuit.py
@@ -194,7 +194,7 @@ class QuantumCircuit:
     def _from_json(cls, path: str | Path) -> QuantumCircuit:
         import json
 
-        loaded_dict: dict = {}
+        loaded_dict: dict = dict()
         if isinstance(path, str):
             path = Path(path)
         try:

--- a/qadence/execution.py
+++ b/qadence/execution.py
@@ -35,7 +35,7 @@ def _n_qubits_block(block: AbstractBlock) -> int:
 def run(
     x: Union[QuantumCircuit, AbstractBlock, Register, int],
     *args: Any,
-    values: dict = {},
+    values: dict | None = None,
     state: Tensor = None,
     backend: BackendName = BackendName.PYQTORCH,
     endianness: Endianness = Endianness.BIG,
@@ -65,7 +65,7 @@ def run(
 @run.register
 def _(
     circuit: QuantumCircuit,
-    values: dict = {},
+    values: dict | None = None,
     state: Tensor = None,
     backend: BackendName = BackendName.PYQTORCH,
     endianness: Endianness = Endianness.BIG,
@@ -79,7 +79,7 @@ def _(
     with no_grad():
         return bknd.run(
             circuit=conv.circuit,
-            param_values=conv.embedding_fn(conv.params, values),
+            param_values=conv.embedding_fn(conv.params, values or dict()),
             state=state,
             endianness=endianness,
         )
@@ -113,7 +113,7 @@ def _(circs: list, **kwargs: Any) -> Tensor:  # type: ignore[misc]
 def sample(
     x: Union[QuantumCircuit, AbstractBlock, Register, int],
     *args: Any,
-    values: dict = {},
+    values: dict | None = None,
     state: Union[Tensor, None] = None,
     n_shots: int = 100,
     backend: BackendName = BackendName.PYQTORCH,
@@ -142,7 +142,7 @@ def sample(
 @sample.register
 def _(
     circuit: QuantumCircuit,
-    values: dict = {},
+    values: dict | None = None,
     state: Union[Tensor, None] = None,
     n_shots: int = 100,
     backend: BackendName = BackendName.PYQTORCH,
@@ -157,7 +157,7 @@ def _(
     conv = bknd.convert(circuit)
     return bknd.sample(
         circuit=conv.circuit,
-        param_values=conv.embedding_fn(conv.params, values),
+        param_values=conv.embedding_fn(conv.params, values or dict()),
         n_shots=n_shots,
         state=state,
         noise=noise,
@@ -185,7 +185,7 @@ def _(block: AbstractBlock, **kwargs: Any) -> Tensor:
 def expectation(
     x: Union[QuantumCircuit, AbstractBlock, Register, int],
     observable: Union[list[AbstractBlock], AbstractBlock],
-    values: dict = {},
+    values: dict | None = None,
     state: Tensor = None,
     backend: BackendName = BackendName.PYQTORCH,
     diff_mode: Union[DiffMode, str, None] = None,
@@ -237,7 +237,7 @@ def expectation(
 def _(
     circuit: QuantumCircuit,
     observable: Union[list[AbstractBlock], AbstractBlock],
-    values: dict = {},
+    values: dict | None = None,
     state: Tensor = None,
     backend: BackendName = BackendName.PYQTORCH,
     diff_mode: Union[DiffMode, str, None] = None,
@@ -257,7 +257,7 @@ def _(
         return bknd.expectation(
             circuit=conv.circuit,
             observable=conv.observable,  # type: ignore[arg-type]
-            param_values=conv.embedding_fn(conv.params, values),
+            param_values=conv.embedding_fn(conv.params, values or dict()),
             state=state,
             measurement=measurement,
             noise=noise,

--- a/qadence/execution.py
+++ b/qadence/execution.py
@@ -35,7 +35,7 @@ def _n_qubits_block(block: AbstractBlock) -> int:
 def run(
     x: Union[QuantumCircuit, AbstractBlock, Register, int],
     *args: Any,
-    values: dict | None = None,
+    values: Union[dict, None] = None,
     state: Tensor = None,
     backend: BackendName = BackendName.PYQTORCH,
     endianness: Endianness = Endianness.BIG,
@@ -65,7 +65,7 @@ def run(
 @run.register
 def _(
     circuit: QuantumCircuit,
-    values: dict | None = None,
+    values: Union[dict, None] = None,
     state: Tensor = None,
     backend: BackendName = BackendName.PYQTORCH,
     endianness: Endianness = Endianness.BIG,
@@ -113,7 +113,7 @@ def _(circs: list, **kwargs: Any) -> Tensor:  # type: ignore[misc]
 def sample(
     x: Union[QuantumCircuit, AbstractBlock, Register, int],
     *args: Any,
-    values: dict | None = None,
+    values: Union[dict, None] = None,
     state: Union[Tensor, None] = None,
     n_shots: int = 100,
     backend: BackendName = BackendName.PYQTORCH,
@@ -142,7 +142,7 @@ def sample(
 @sample.register
 def _(
     circuit: QuantumCircuit,
-    values: dict | None = None,
+    values: Union[dict, None] = None,
     state: Union[Tensor, None] = None,
     n_shots: int = 100,
     backend: BackendName = BackendName.PYQTORCH,
@@ -185,7 +185,7 @@ def _(block: AbstractBlock, **kwargs: Any) -> Tensor:
 def expectation(
     x: Union[QuantumCircuit, AbstractBlock, Register, int],
     observable: Union[list[AbstractBlock], AbstractBlock],
-    values: dict | None = None,
+    values: Union[dict, None] = None,
     state: Tensor = None,
     backend: BackendName = BackendName.PYQTORCH,
     diff_mode: Union[DiffMode, str, None] = None,
@@ -237,7 +237,7 @@ def expectation(
 def _(
     circuit: QuantumCircuit,
     observable: Union[list[AbstractBlock], AbstractBlock],
-    values: dict | None = None,
+    values: Union[dict, None] = None,
     state: Tensor = None,
     backend: BackendName = BackendName.PYQTORCH,
     diff_mode: Union[DiffMode, str, None] = None,

--- a/qadence/ml_tools/printing.py
+++ b/qadence/ml_tools/printing.py
@@ -27,8 +27,9 @@ def print_metrics(loss: float | None, metrics: dict, iteration: int) -> None:
 
 
 def write_tensorboard(
-    writer: SummaryWriter, loss: float = None, metrics: dict = {}, iteration: int = 0
+    writer: SummaryWriter, loss: float = None, metrics: dict | None = None, iteration: int = 0
 ) -> None:
+    metrics = metrics or dict()
     if loss is not None:
         writer.add_scalar("loss", loss, iteration)
     for key, arg in metrics.items():

--- a/qadence/parameters.py
+++ b/qadence/parameters.py
@@ -228,7 +228,7 @@ def sympy_to_numeric(expr: Basic) -> TNumber:
         return float(expr)
 
 
-def evaluate(expr: Expr, values: dict = {}, as_torch: bool = False) -> TNumber | Tensor:
+def evaluate(expr: Expr, values: dict | None = None, as_torch: bool = False) -> TNumber | Tensor:
     """
     Arguments:
 
@@ -260,7 +260,8 @@ def evaluate(expr: Expr, values: dict = {}, as_torch: bool = False) -> TNumber |
     """
     res: Basic
     res_value: TNumber | Tensor
-    query: dict[Parameter, TNumber | Tensor] = {}
+    query: dict[Parameter, TNumber | Tensor] = dict()
+    values = values or dict()
     if isinstance(expr, Array):
         return Tensor(expr.tolist())
     else:

--- a/tests/backends/horqrux/test_quantum_horqrux.py
+++ b/tests/backends/horqrux/test_quantum_horqrux.py
@@ -36,7 +36,7 @@ from qadence.constructors import hea
 def test_psr_firstOrder() -> None:
     circ = QuantumCircuit(2, hea(2, 1))
     v_list = []
-    grad_dict = {}
+    grad_dict = dict()
     for diff_mode in ["ad", "gpsr"]:
         hq_bknd = backend_factory("horqrux", diff_mode)
         hq_circ, hq_obs, hq_fn, hq_params = hq_bknd.convert(circ, Z(0))
@@ -60,7 +60,7 @@ def test_psr_firstOrder() -> None:
 def test_psr_d3fdx(batch_size: int, obs: AbstractBlock) -> None:
     n_qubits: int = 2
     circ = QuantumCircuit(n_qubits, RX(0, "theta"))
-    grad_dict = {}
+    grad_dict = dict()
     for diff_mode in ["ad", "gpsr"]:
         hq_bknd = backend_factory("horqrux", diff_mode)
         hq_circ, hq_obs, hq_fn, hq_params = hq_bknd.convert(circ, obs)
@@ -85,7 +85,7 @@ def test_psr_d3fdx(batch_size: int, obs: AbstractBlock) -> None:
 def test_psr_2nd_order_mixed(batch_size: int, obs: AbstractBlock) -> None:
     n_qubits: int = 2
     circ = QuantumCircuit(n_qubits, hea(n_qubits=n_qubits, depth=1))
-    grad_dict = {}
+    grad_dict = dict()
     for diff_mode in ["ad", "gpsr"]:
         hq_bknd = backend_factory("horqrux", diff_mode)
         hq_circ, hq_obs, hq_fn, hq_params = hq_bknd.convert(circ, obs)

--- a/tests/qadence/test_matrices.py
+++ b/tests/qadence/test_matrices.py
@@ -66,9 +66,9 @@ from qadence.types import BasisSet, Interaction, ReuploadScaling
 
 
 def _calc_mat_vec_wavefunction(
-    block: AbstractBlock, n_qubits: int, init_state: torch.Tensor, values: dict = {}
+    block: AbstractBlock, n_qubits: int, init_state: torch.Tensor, values: dict | None = None
 ) -> torch.Tensor:
-    mat = block_to_tensor(block, values, tuple(range(n_qubits)))
+    mat = block_to_tensor(block, values or dict(), tuple(range(n_qubits)))
     return torch.einsum("bij,kj->bi", mat, init_state)
 
 


### PR DESCRIPTION
Solves #590 

Replace empty dicts default values on functions and methods calls to `None` and resolving them inside the code as `arg = arg or dict()`.
