### PR TITLE
[Feature] Setting digital noise in addition to readout noise in Pyq backend functions sample and expectation

### DIFF
--- a/qadence/backends/pyqtorch/backend.py
+++ b/qadence/backends/pyqtorch/backend.py
@@ -109,7 +109,8 @@ class Backend(BackendInterface):
         if len(passes) > 0:
             circuit = transpile(*passes)(circuit)
         # setting noise on blocks
-        set_noise(circuit, self.config.noise)
+        if self.config.noise:
+            set_noise(circuit, self.config.noise)
 
         ops = convert_block(circuit.block, n_qubits=circuit.n_qubits, config=self.config)
         readout_noise = (

--- a/qadence/backends/pyqtorch/convert_ops.py
+++ b/qadence/backends/pyqtorch/convert_ops.py
@@ -178,8 +178,20 @@ def convert_block(
     block: AbstractBlock,
     n_qubits: int = None,
     config: Configuration = None,
-    apply_noise: bool = True,
 ) -> Sequence[Module | Tensor | str | sympy.Expr]:
+    """Convert block to native Pyqtorch representation.
+
+    Args:
+        block (AbstractBlock): Block to convert.
+        n_qubits (int, optional): Number of qubits. Defaults to None.
+        config (Configuration, optional): Backend configuration instance. Defaults to None.
+
+    Raises:
+        NotImplementedError: For non supported blocks.
+
+    Returns:
+        Sequence[Module | Tensor | str | sympy.Expr]: Lis of native operations.
+    """
     if isinstance(block, (Tensor, str, sympy.Expr)):  # case for hamevo generators
         if isinstance(block, Tensor):
             block = block.permute(1, 2, 0)  # put batch size in the back
@@ -192,7 +204,7 @@ def convert_block(
         config = Configuration()
 
     noise: NoiseHandler | None = None
-    if apply_noise and hasattr(block, "noise") and block.noise:
+    if hasattr(block, "noise") and block.noise:
         noise = convert_digital_noise(block.noise)
 
     if isinstance(block, ScaleBlock):

--- a/qadence/backends/pyqtorch/convert_ops.py
+++ b/qadence/backends/pyqtorch/convert_ops.py
@@ -175,7 +175,10 @@ def sympy_to_pyq(expr: sympy.Expr) -> ConcretizedCallable | Tensor:
 
 
 def convert_block(
-    block: AbstractBlock, n_qubits: int = None, config: Configuration = None
+    block: AbstractBlock,
+    n_qubits: int = None,
+    config: Configuration = None,
+    apply_noise: bool = True,
 ) -> Sequence[Module | Tensor | str | sympy.Expr]:
     if isinstance(block, (Tensor, str, sympy.Expr)):  # case for hamevo generators
         if isinstance(block, Tensor):
@@ -189,7 +192,7 @@ def convert_block(
         config = Configuration()
 
     noise: NoiseHandler | None = None
-    if hasattr(block, "noise") and block.noise:
+    if apply_noise and hasattr(block, "noise") and block.noise:
         noise = convert_digital_noise(block.noise)
 
     if isinstance(block, ScaleBlock):

--- a/qadence/noise/protocols.py
+++ b/qadence/noise/protocols.py
@@ -149,7 +149,11 @@ class NoiseHandler:
         return list(filter(lambda el: not el.startswith("__"), dir(cls)))
 
     def filter(self, protocol: NoiseEnum | str) -> NoiseHandler | None:
-        is_protocol: list = [p == protocol or isinstance(p, protocol) for p in self.protocol]  # type: ignore[arg-type]
+        is_protocol: list = list()
+        if protocol == NoiseProtocol.READOUT:
+            is_protocol = [p == protocol for p in self.protocol]
+        else:
+            is_protocol = [isinstance(p, protocol) for p in self.protocol]  # type: ignore[arg-type]
         return (
             NoiseHandler(
                 list(compress(self.protocol, is_protocol)),

--- a/qadence/noise/protocols.py
+++ b/qadence/noise/protocols.py
@@ -155,7 +155,7 @@ class NoiseHandler:
                 list(compress(self.protocol, is_protocol)),
                 list(compress(self.options, is_protocol)),
             )
-            if len(is_protocol) > 0
+            if len(is_protocol) > 0 and sum(is_protocol) > 0
             else None
         )
 


### PR DESCRIPTION
Complementing #591 and #599 where digital and readout noise can be set in the converted circuit from `sample` and `expectation`, without the user calling `set_noise` beforehand.