### PR TITLE
[Feature] use_full_support default to False for block_to_tensor

### DIFF
--- a/qadence/blocks/block_to_tensor.py
+++ b/qadence/blocks/block_to_tensor.py
@@ -265,7 +265,7 @@ def _gate_parameters(b: AbstractBlock, values: dict[str, torch.Tensor]) -> tuple
 def block_to_diagonal(
     block: AbstractBlock,
     qubit_support: tuple | list | None = None,
-    use_full_support: bool = True,
+    use_full_support: bool = False,
     endianness: Endianness = Endianness.BIG,
     device: torch.device = None,
 ) -> torch.Tensor:
@@ -309,7 +309,7 @@ def block_to_tensor(
     block: AbstractBlock,
     values: dict[str, TNumber | torch.Tensor] = {},
     qubit_support: tuple | None = None,
-    use_full_support: bool = True,
+    use_full_support: bool = False,
     tensor_type: TensorType = TensorType.DENSE,
     endianness: Endianness = Endianness.BIG,
     device: torch.device = None,
@@ -369,7 +369,7 @@ def _block_to_tensor_embedded(
     block: AbstractBlock,
     values: dict[str, TNumber | torch.Tensor] = {},
     qubit_support: tuple | None = None,
-    use_full_support: bool = True,
+    use_full_support: bool = False,
     endianness: Endianness = Endianness.BIG,
     device: torch.device = None,
 ) -> torch.Tensor:

--- a/qadence/mitigations/analog_zne.py
+++ b/qadence/mitigations/analog_zne.py
@@ -92,7 +92,9 @@ def pulse_experiment(
         )
     # Convert observable to Numpy types compatible with QuTip simulations.
     # Matrices are flipped to match QuTip conventions.
-    converted_observable = [np.flip(block_to_tensor(obs).numpy()) for obs in observable]
+    converted_observable = [
+        np.flip(block_to_tensor(obs, use_full_support=True).numpy()) for obs in observable
+    ]
     # Create ZNE datasets by looping over batches.
     for observable in converted_observable:
         # Get expectation values at the end of the time serie [0,t]
@@ -130,7 +132,9 @@ def noise_level_experiment(
     )
     # Convert observable to Numpy types compatible with QuTip simulations.
     # Matrices are flipped to match QuTip conventions.
-    converted_observable = [np.flip(block_to_tensor(obs).numpy()) for obs in observable]
+    converted_observable = [
+        np.flip(block_to_tensor(obs, use_full_support=True).numpy()) for obs in observable
+    ]
     # Create ZNE datasets by looping over batches.
     for observable in converted_observable:
         # Get expectation values at the end of the time serie [0,t]

--- a/tests/qadence/test_matrices.py
+++ b/tests/qadence/test_matrices.py
@@ -17,6 +17,7 @@ from qadence.blocks import (
     ParametricBlock,
     ParametricControlBlock,
     embedding,
+    MatrixBlock,
 )
 from qadence.blocks.block_to_tensor import (
     IMAT,
@@ -578,20 +579,27 @@ def test_projector_composition_unitaries(
     assert torch.allclose(block_to_tensor(projector), block_to_tensor(exp_projector), atol=ATOL_64)
 
 
+@pytest.mark.parametrize("use_full_support", [True, False])
 @given(st.batched_digital_circuits())
 @settings(deadline=None)
-def test_embedded(circ_and_inputs: tuple[QuantumCircuit, dict[str, torch.Tensor]]) -> None:
+def test_embedded(
+    use_full_support: bool, circ_and_inputs: tuple[QuantumCircuit, dict[str, torch.Tensor]]
+) -> None:
     circ, inputs = circ_and_inputs
     ps, embed = embedding(circ.block, to_gate_params=False)
-    m = block_to_tensor(circ.block, inputs, use_full_support=True)
+    m = block_to_tensor(circ.block, inputs, use_full_support=use_full_support)
     m_embedded = _block_to_tensor_embedded(
-        circ.block, values=embed(ps, inputs), use_full_support=True
+        circ.block, values=embed(ps, inputs), use_full_support=use_full_support
     )
+    assert torch.allclose(m, m_embedded)
     zro_state = zero_state(circ.n_qubits)
     wf_run = run(circ, values=inputs)
-    wf_embedded = torch.einsum("bij,kj->bi", m_embedded, zro_state)
-    wf_nonembedded = torch.einsum("bij,kj->bi", m, zro_state)
-    assert torch.allclose(m, m_embedded)
+    if use_full_support:
+        wf_embedded = torch.einsum("bij,kj->bi", m_embedded, zro_state)
+        wf_nonembedded = torch.einsum("bij,kj->bi", m, zro_state)
+    else:
+        wf_embedded = run(circ, values=embed(ps, inputs))
+        wf_nonembedded = wf_run
     assert equivalent_state(wf_run, wf_embedded, atol=ATOL_E6)
     assert equivalent_state(wf_run, wf_nonembedded, atol=ATOL_E6)
 

--- a/tests/qadence/test_matrices.py
+++ b/tests/qadence/test_matrices.py
@@ -544,7 +544,7 @@ def _calc_mat_vec_wavefunction(
     ],
 )
 def test_projector_tensor(projector: AbstractBlock, exp_projector_mat: Tensor) -> None:
-    projector_mat = block_to_tensor(projector)
+    projector_mat = block_to_tensor(projector, use_full_support=True)
     assert torch.allclose(projector_mat, exp_projector_mat, atol=1.0e-4)
 
 
@@ -583,8 +583,10 @@ def test_projector_composition_unitaries(
 def test_embedded(circ_and_inputs: tuple[QuantumCircuit, dict[str, torch.Tensor]]) -> None:
     circ, inputs = circ_and_inputs
     ps, embed = embedding(circ.block, to_gate_params=False)
-    m = block_to_tensor(circ.block, inputs)
-    m_embedded = _block_to_tensor_embedded(circ.block, values=embed(ps, inputs))
+    m = block_to_tensor(circ.block, inputs, use_full_support=True)
+    m_embedded = _block_to_tensor_embedded(
+        circ.block, values=embed(ps, inputs), use_full_support=True
+    )
     zro_state = zero_state(circ.n_qubits)
     wf_run = run(circ, values=inputs)
     wf_embedded = torch.einsum("bij,kj->bi", m_embedded, zro_state)

--- a/tests/qadence/test_operators.py
+++ b/tests/qadence/test_operators.py
@@ -279,7 +279,7 @@ def test_to_matrix(block_and_mat: tuple[AbstractBlock, np.ndarray]) -> None:
 def test_from_openfermion(qubit_op: QubitOperator) -> None:
     obs = from_openfermion(qubit_op)
     expected_mat = get_sparse_operator(qubit_op).toarray()
-    np_mat = block_to_tensor(obs).squeeze().numpy()
+    np_mat = block_to_tensor(obs, use_full_support=True).squeeze().numpy()
     assert np.array_equal(np_mat, expected_mat)
     op = to_openfermion(obs)
     assert op == qubit_op


### PR DESCRIPTION
Solves #10 . Mostly this has been solved in PyQTorch and we just set default values where it was needed.