### PR TITLE
set_trainable update

### DIFF
--- a/docs/content/parameters.md
+++ b/docs/content/parameters.md
@@ -51,6 +51,25 @@ print(f"{wf = }") # markdown-exec: hide
 
 Since a batch of input values was passed, the `run` function returns a batch of output states. Note that `FeatureParameter("x")` and `VariationalParameter("x")` are simply aliases for `Parameter("x", trainable = False)` and `Parameter("x", trainable = True)`.
 
+## Switching Between Feature Parameters and Variational Parameters
+
+If you want to switch between **feature parameters** and **variational parameters**, you can use `set_trainable` to modify the `trainable` attribute of the variable. Additionally, `set_trainable` can apply the same `trainable` option to multiple blocks if the input is provided in the format `List[blocks]`.
+
+```python exec="on" source="material-block" result="json"
+from qadence import RX, VariationalParameter, set_trainable
+from qadence.blocks.utils import parameters # markdown-exec: hide
+
+variational_block = [RX(0, VariationalParameter("theta")), RX(1, VariationalParameter("phi"))]
+
+for gate in variational_block: # markdown-exec: hide
+    print(f"trainable is set to {parameters(gate)[0].trainable} in {gate}")  # markdown-exec: hide
+
+feature_block = set_trainable(variational_block, False)
+
+for gate in feature_block: # markdown-exec: hide
+    print(f"trainable is set to {parameters(gate)[0].trainable} in {gate}")  # markdown-exec: hide
+```
+
 ## Multiparameter expressions and analog integration
 
 The integration with Sympy becomes useful when one wishes to write arbitrary parameter compositions. Parameters can also be used as scaling coefficients in the block system, which is essential when defining arbitrary analog operations.

--- a/qadence/transpile/block.py
+++ b/qadence/transpile/block.py
@@ -50,7 +50,7 @@ def set_trainable(
         blocks (AbstractBlock | list[AbstractBlock]): Block or list of blocks for which
             to set the trainable attribute
         value (bool, optional): The value of the trainable attribute to assign to the input blocks
-        inplace (bool, optional): Whether to modify the block(s) in place or not. Currently, only
+        inplace (bool, optional): Whether to modify the block(s) in place or not. Currently, only `True` is available.
 
     Raises:
         NotImplementedError: if the `inplace` argument is set to False, the function will


### PR DESCRIPTION
closes #535.

- [x] Update [Parameters](https://pasqal-io.github.io/qadence/latest/content/parameters/) documentation
  - [x] `set_trainable` feature
- [ ] Update [QuantumModel](https://pasqal-io.github.io/qadence/latest/content/quantummodels/) documentation
  - [ ] `reset_vparams` feature
  - [ ] getting derivatives w.r.t trainable parameters
  - [ ] obtaining parameter dict at a given training epoch
- [ ] Whole `model config` option documentation