### PR TITLE
[Bug] Limit jax due to sympy2jax errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ visualization = [
 ]
 horqrux = [
     "horqrux==0.8.0",
-    "jax",
+    "jax<0.6.0",
     "flax",
     "optax",
     "jaxopt",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 license = { text = "PASQAL OPEN-SOURCE SOFTWARE LICENSE (MIT-derived)" }
-version = "1.11.2"
+version = "1.11.3"
 classifiers = [
     "License :: Other/Proprietary License",
     "Programming Language :: Python",


### PR DESCRIPTION
With the new jax update of 0.6, sympy2jax throws errors.